### PR TITLE
Remove base.py classes from docs

### DIFF
--- a/fiasco/__init__.py
+++ b/fiasco/__init__.py
@@ -9,8 +9,7 @@ from ._sunpy_init import *
 if not _ASTROPY_SETUP_:
     from .util.util import setup_paths
     defaults = setup_paths()
-    
-    from .base import *
+
     from .fiasco import *
     from .level import *
     from .ion import *

--- a/fiasco/tests/test_base.py
+++ b/fiasco/tests/test_base.py
@@ -8,8 +8,13 @@ from fiasco.util.exceptions import MissingIonError
 
 
 @pytest.fixture
+<<<<<<< HEAD
 def ionbase(hdf5_dbase_root):
     return fiasco.IonBase('fe 5', hdf5_dbase_root=hdf5_dbase_root)
+=======
+def ionbase():
+    return fiasco.base.IonBase('fe 5')
+>>>>>>> Fix test imports
 
 
 def test_ion_name(ionbase):
@@ -38,7 +43,7 @@ def test_charge_state(ionbase):
 
 
 def test_create_ion_symbol_lower(hdf5_dbase_root):
-    ion = fiasco.IonBase('h 1', hdf5_dbase_root=hdf5_dbase_root)
+    ion = fiasco.base.IonBase('h 1', hdf5_dbase_root=hdf5_dbase_root)
     assert ion.element_name == 'hydrogen'
     assert ion.atomic_symbol == 'H'
     assert ion.atomic_number == 1
@@ -48,7 +53,7 @@ def test_create_ion_symbol_lower(hdf5_dbase_root):
 
 
 def test_create_ion_symbol_upper(hdf5_dbase_root):
-    ion = fiasco.IonBase('H 1', hdf5_dbase_root=hdf5_dbase_root)
+    ion = fiasco.base.IonBase('H 1', hdf5_dbase_root=hdf5_dbase_root)
     assert ion.element_name == 'hydrogen'
     assert ion.atomic_symbol == 'H'
     assert ion.atomic_number == 1
@@ -58,7 +63,7 @@ def test_create_ion_symbol_upper(hdf5_dbase_root):
 
 
 def test_create_ion_charge_state(hdf5_dbase_root):
-    ion = fiasco.IonBase('h +0', hdf5_dbase_root=hdf5_dbase_root)
+    ion = fiasco.base.IonBase('h +0', hdf5_dbase_root=hdf5_dbase_root)
     assert ion.element_name == 'hydrogen'
     assert ion.atomic_symbol == 'H'
     assert ion.atomic_number == 1
@@ -68,7 +73,7 @@ def test_create_ion_charge_state(hdf5_dbase_root):
 
 
 def test_create_ion_element_name(hdf5_dbase_root):
-    ion = fiasco.IonBase('hydrogen 1', hdf5_dbase_root=hdf5_dbase_root)
+    ion = fiasco.base.IonBase('hydrogen 1', hdf5_dbase_root=hdf5_dbase_root)
     assert ion.element_name == 'hydrogen'
     assert ion.atomic_symbol == 'H'
     assert ion.atomic_number == 1

--- a/fiasco/tests/test_base.py
+++ b/fiasco/tests/test_base.py
@@ -8,13 +8,8 @@ from fiasco.util.exceptions import MissingIonError
 
 
 @pytest.fixture
-<<<<<<< HEAD
 def ionbase(hdf5_dbase_root):
-    return fiasco.IonBase('fe 5', hdf5_dbase_root=hdf5_dbase_root)
-=======
-def ionbase():
-    return fiasco.base.IonBase('fe 5')
->>>>>>> Fix test imports
+    return fiasco.base.IonBase('fe 5', hdf5_dbase_root=hdf5_dbase_root)
 
 
 def test_ion_name(ionbase):

--- a/fiasco/tests/test_base.py
+++ b/fiasco/tests/test_base.py
@@ -79,4 +79,4 @@ def test_create_ion_element_name(hdf5_dbase_root):
 
 def test_create_invalid_ion_raises_missing_ion_error(hdf5_dbase_root):
     with pytest.raises(MissingIonError):
-        fiasco.IonBase('hydrogen 3', hdf5_dbase_root=hdf5_dbase_root)
+        fiasco.base.IonBase('hydrogen 3', hdf5_dbase_root=hdf5_dbase_root)


### PR DESCRIPTION
Should fix #47 , and also avoid users being able to import the base classes from the top level namesapce