### PR TITLE
Allow scalar temperature input to Ion()

### DIFF
--- a/fiasco/ion.py
+++ b/fiasco/ion.py
@@ -46,7 +46,7 @@ class Ion(IonBase, ContinuumBase):
     @u.quantity_input
     def __init__(self, ion_name, temperature: u.K, *args, **kwargs):
         super().__init__(ion_name, *args, **kwargs)
-        self.temperature = temperature
+        self.temperature = np.atleast_1d(temperature)
         # Get selected datasets
         # TODO: do not hardcode defaults, pull from rc file
         self._dset_names = {}

--- a/fiasco/tests/test_ion.py
+++ b/fiasco/tests/test_ion.py
@@ -26,6 +26,14 @@ def test_level_indexing(ion):
     assert isinstance(ion[0], fiasco.ion.Level)
 
 
+def test_repr(ion):
+    assert 'Fe 5' in ion.__repr__()
+
+
+def test_repr_scalar_temp(ion):
+    assert 'Fe 5' in fiasco.Ion('Fe 5', 1e6 * u.K).__repr__()
+
+
 def test_level_properties(ion):
     assert hasattr(ion[0], 'level')
     assert hasattr(ion[0], 'energy')


### PR DESCRIPTION
Previously `__repr__` and probably other things failed if the temperature input to `Ion()` was a scalar. Also added a test for `__repr__`.