### PR TITLE
Fix plots in tutorial docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: true
 branches:
     only: master
 os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
     - env: SETUP_CMD='test --pep8'
     - env:
       - SETUP_CMD='build_docs'
-      - READTHEDOCS=true  # fake RTD so that the database will be downloaded and built
+      - READTHEDOCS=True  # fake RTD so that the database will be downloaded and built
   allow_failures:
     - env: SETUP_CMD='test --pep8'
       python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: true
 branches:
     only: master
 os: linux
@@ -21,9 +20,7 @@ jobs:
     - env: SETUP_CMD='test --coverage'
       after_success: coveralls --rcfile='fiasco/tests/coveragerc'
     - env: SETUP_CMD='test --pep8'
-    - env:
-      - SETUP_CMD='build_docs'
-      - READTHEDOCS=True  # fake RTD so that the database will be downloaded and built
+    - env: SETUP_CMD='build_docs'
   allow_failures:
     - env: SETUP_CMD='test --pep8'
       python: 3.7

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,12 +31,14 @@ import os
 import sys
 
 ON_RTD = os.environ.get('READTHEDOCS') == 'True'
+ON_TRAVIS = os.environ.get('TRAVIS') == 'true'
 
 # On Read the Docs, download the database and build a minimal HDF5 version
-if ON_RTD:
+if ON_RTD or ON_TRAVIS:
     from fiasco.util import download_dbase, build_hdf5_dbase
     from fiasco.util.setup_db import CHIANTI_URL, LATEST_VERSION
-    os.environ['HOME'] = '/home/docs'
+    if ON_RTD:
+        os.environ['HOME'] = '/home/docs'  # RTD does not set HOME?
     FIASCO_HOME = os.path.join(os.environ['HOME'], '.fiasco')
     if not os.path.exists(FIASCO_HOME):
         os.makedirs(FIASCO_HOME)

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -116,7 +116,7 @@ The equilibrium population fractions are interpolated to `temperature` and can b
     import numpy as np
     import astropy.units as u
     from fiasco import Ion
-    ion = Ion('Fe 15', np.logspace(5, 7, 100) * u.K, hdf5_dbase_root=getfixture('hdf5_dbase_root'))
+    ion = Ion('Fe 15', np.logspace(5, 7, 100) * u.K)
     plt.plot(ion.temperature, ion.ioneq)
     plt.xlabel(r'$T [K]$')
     plt.ylabel(r'Population Fraction')
@@ -136,7 +136,7 @@ In addition to providing an API to the CHIANTI data, `Ion` also provides several
     import numpy as np
     import astropy.units as u
     from fiasco import Ion
-    ion = Ion('Fe 18', np.logspace(4, 8, 100) * u.K, hdf5_dbase_root=getfixture('hdf5_dbase_root'))
+    ion = Ion('Fe 18', np.logspace(4, 8, 100) * u.K)
     plt.plot(ion.temperature, ion.recombination_rate(), label='Total')
     plt.plot(ion.temperature, ion.dielectronic_recombination_rate(), label='Dielectronic')
     plt.plot(ion.temperature, ion.radiative_recombination_rate(), label='Radiative')


### PR DESCRIPTION
No need to put fixtures in the example plot code. These are not run in the doctests.

Bugfix in CI config so that the database is configured for the docs build tests