### PR TITLE
Misc speedups

### DIFF
--- a/fiasco/base.py
+++ b/fiasco/base.py
@@ -19,17 +19,11 @@ class Base(object):
     """
 
     def __init__(self, ion_name, hdf5_dbase_root=None, **kwargs):
-        element, ion = ion_name.split()
+        self._element, ion = ion_name.split()
         if '+' in ion:
             ion = f"{int(ion.strip('+')) + 1}"
-        self.atomic_number = plasmapy.atomic.atomic_number(element.capitalize())
-        self.element_name = plasmapy.atomic.element_name(element.capitalize())
-        self.atomic_symbol = plasmapy.atomic.atomic_symbol(element.capitalize())
         self.ionization_stage = int(ion)
         self.charge_state = self.ionization_stage - 1
-        self.ion_name = f'{self.atomic_symbol} {self.ionization_stage}'
-        # Old CHIANTI format, only preserved for internal data access
-        self._ion_name = f'{self.atomic_symbol.lower()}_{self.ionization_stage}'
 
         if hdf5_dbase_root is None:
             self.hdf5_dbase_root = fiasco.defaults['hdf5_dbase_root']
@@ -45,6 +39,27 @@ class Base(object):
             source = (self.hdf5_dbase_root if not fiasco.defaults['use_remote_data']
                       else fiasco.defaults['remote_endpoint'])
             raise MissingIonError(f'{self.ion_name} not found in {source}')
+
+    @property
+    def atomic_number(self):
+        return plasmapy.atomic.atomic_number(self._element.capitalize())
+
+    @property
+    def element_name(self):
+        return plasmapy.atomic.element_name(self._element.capitalize())
+
+    @property
+    def atomic_symbol(self):
+        return plasmapy.atomic.atomic_symbol(self._element.capitalize())
+
+    @property
+    def ion_name(self):
+        return f'{self.atomic_symbol} {self.ionization_stage}'
+
+    @property
+    def _ion_name(self):
+        # Old CHIANTI format, only preserved for internal data access
+        return f'{self.atomic_symbol.lower()}_{self.ionization_stage}'
 
 
 class ContinuumBase(Base):

--- a/fiasco/tests/test_ion.py
+++ b/fiasco/tests/test_ion.py
@@ -31,6 +31,11 @@ def test_repr(ion):
 def test_repr_scalar_temp(ion, hdf5_dbase_root):
     assert 'Fe 5' in fiasco.Ion('Fe 5', 1e6 * u.K, hdf5_dbase_root=hdf5_dbase_root).__repr__()
 
+def test_ion_properties(ion):
+    assert ion.atomic_number == 26
+    assert ion.element_name == 'iron'
+    assert ion.atomic_symbol == 'Fe'
+    assert ion.ion_name == 'Fe 5'
 
 def test_level_properties(ion):
     assert hasattr(ion[0], 'level')


### PR DESCRIPTION
- Lazily evaluate names in `Ion` so they aren't calculated every time an `Ion` is created.
- Move a multiplication out of a for loop