### PR TITLE
Fix bt descale vectorize

### DIFF
--- a/fiasco/ion.py
+++ b/fiasco/ion.py
@@ -12,7 +12,7 @@ from .collections import IonCollection
 from .level import Level, Transitions
 from fiasco import proton_electron_ratio
 from fiasco.util import (needs_dataset, vectorize_where, vectorize_where_sum,
-                         burgess_tully_descale_vectorize)
+                         burgess_tully_descale)
 
 __all__ = ['Ion']
 
@@ -157,11 +157,11 @@ Using Datasets:
         fiasco.util.burgess_tully_descale : Descale and interpolate :math:`\\Upsilon`
         """
         kBTE = np.outer(const.k_B*self.temperature, 1.0/self._scups['delta_energy'])
-        upsilon = burgess_tully_descale_vectorize(self._scups['bt_t'],
-                                                  self._scups['bt_upsilon'],
-                                                  kBTE.T,
-                                                  self._scups['bt_c'],
-                                                  self._scups['bt_type'])
+        upsilon = burgess_tully_descale(self._scups['bt_t'],
+                                        self._scups['bt_upsilon'],
+                                        kBTE.T,
+                                        self._scups['bt_c'],
+                                        self._scups['bt_type'])
         upsilon = u.Quantity(np.where(upsilon > 0., upsilon, 0.))
         return upsilon.T
 
@@ -223,8 +223,11 @@ Using Datasets:
         bt_t = [np.linspace(0, 1, ups.shape[0]) for ups in self._psplups['bt_rate']]
         # Get excitation rates directly from scaled data
         kBTE = np.outer(const.k_B*self.temperature, 1.0/self._psplups['delta_energy'])
-        ex_rate = burgess_tully_descale_vectorize(
-            bt_t, self._psplups['bt_rate'], kBTE.T, self._psplups['bt_c'], self._psplups['bt_type'])
+        ex_rate = burgess_tully_descale(bt_t,
+                                        self._psplups['bt_rate'],
+                                        kBTE.T,
+                                        self._psplups['bt_c'],
+                                        self._psplups['bt_type'])
         return u.Quantity(np.where(ex_rate > 0., ex_rate, 0.), u.cm**3/u.s).T
 
     @needs_dataset('elvlc', 'psplups')
@@ -555,11 +558,11 @@ Using Datasets:
         # temperature when computing rate
         kBTE = kBTE.T
         xs = [np.linspace(0, 1, ups.shape[0]) for ups in self._easplups['bt_upsilon']]
-        upsilon = burgess_tully_descale_vectorize(xs,
-                                                  self._easplups['bt_upsilon'].value,
-                                                  kBTE,
-                                                  self._easplups['bt_c'].value,
-                                                  self._easplups['bt_type'])
+        upsilon = burgess_tully_descale(xs,
+                                        self._easplups['bt_upsilon'].value,
+                                        kBTE,
+                                        self._easplups['bt_c'].value,
+                                        self._easplups['bt_type'])
         # NOTE: The 1/omega multiplicity factor is already included in the scaled upsilon
         # values provided by CHIANTI
         rate = c * upsilon * np.exp(-1 / kBTE) / np.sqrt(self.temperature)

--- a/fiasco/util/tests/test_tools.py
+++ b/fiasco/util/tests/test_tools.py
@@ -1,15 +1,45 @@
 import numpy as np
 
-from fiasco.util import burgess_tully_descale_vectorize, burgess_tully_descale
+from fiasco.util import burgess_tully_descale
 
 
-def test_burgess_tully():
-    # Check that normal and vectorized versions give the same result
+def test_burgess_tully_one_array():
     x = np.linspace(0, 1, 10)
     y = x**1.6 + 10
-    energy_ratio = np.ones(x.shape)
+    energy_ratio = np.ones((1,) + x.shape)
     c = 1
     for scaling_type in range(1, 7):
-        out = burgess_tully_descale(x, y, energy_ratio, c, scaling_type)
-        out_vect = burgess_tully_descale_vectorize(x, y, energy_ratio, c, scaling_type)
-        np.testing.assert_equal(out, out_vect[0])
+        ups = burgess_tully_descale(x, y, energy_ratio, c, scaling_type)
+        assert ups.shape == energy_ratio.shape
+
+
+def test_burgess_tully_2d_array():
+    x = np.tile(np.linspace(0, 1, 10), (2, 1))
+    y = x**1.6 + 10
+    energy_ratio = np.ones(x.shape[:1] + (10,))
+    c = 1*np.ones(x.shape[:1])
+    for scaling_type in range(1, 7):
+        st = scaling_type*np.ones(c.shape)
+        ups = burgess_tully_descale(x, y, energy_ratio, c, st)
+        assert ups.shape == energy_ratio.shape
+
+
+def test_burgess_tully_different_scaling_types():
+    x = np.tile(np.linspace(0, 1, 10), (6, 1))
+    y = x**1.6 + 10
+    energy_ratio = np.ones(x.shape[:1] + (10,))
+    c = 1*np.ones(x.shape[:1])
+    scaling_type = np.arange(1, 7)
+    ups = burgess_tully_descale(x, y, energy_ratio, c, scaling_type)
+    assert ups.shape == energy_ratio.shape
+
+
+def test_burgess_tully_staggered_array():
+    x = np.array([np.linspace(0, 1, 5), np.linspace(0, 1, 9)])
+    y = x**1.6 + 10
+    energy_ratio = np.ones(x.shape[:1] + (10,))
+    c = 1*np.ones(x.shape)
+    for scaling_type in range(1, 7):
+        st = scaling_type*np.ones(c.shape)
+        ups = burgess_tully_descale(x, y, energy_ratio, c, st)
+        assert ups.shape == energy_ratio.shape


### PR DESCRIPTION
Fixes #77. The issue was with casting the staggered array to a 2D array as this added a superfluous dimension that threw off the `map` call.

I've gotten rid of the separate `_vectorize` function and just consolidated into a single one that accepts all needed input types. I've also modified the tests to test all of these different input types.