### PR TITLE
Detect a local copy of the database when testing

### DIFF
--- a/fiasco/conftest.py
+++ b/fiasco/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from astropy.tests.plugins import *
 
 from fiasco.util import build_hdf5_dbase, download_dbase
-from fiasco.util.setup_db import CHIANTI_URL, LATEST_VERSION
+from fiasco.util.setup_db import CHIANTI_URL, LATEST_VERSION, FIASCO_HOME
 
 # Minimal set of CHIANTI files needed to run the tests
 TEST_FILES = [
@@ -37,6 +37,12 @@ TEST_FILES = [
 
 @pytest.fixture(scope='session')
 def ascii_dbase_root(tmpdir_factory):
+    # If we already have a local copy, just return the path to that
+    local_dbase_path = os.path.join(FIASCO_HOME, 'chianti_dbase')
+    if os.path.exists(local_dbase_path):
+        return local_dbase_path
+
+    # Otherwise download the database
     path = tmpdir_factory.mktemp('chianti_dbase')
     download_dbase(CHIANTI_URL.format(version=LATEST_VERSION), path)
     return path


### PR DESCRIPTION
See #74. This detects if a local copy of the ASCII database is present, and if so uses that to build the h5 database needed for testing.

Perhaps there should be SHA checks on the files to check they are as expected?