### PR TITLE
Remove remote datalayer

### DIFF
--- a/fiasco/base.py
+++ b/fiasco/base.py
@@ -35,16 +35,11 @@ class Base(object):
             self.hdf5_dbase_root = fiasco.defaults['hdf5_dbase_root']
         else:
             self.hdf5_dbase_root = hdf5_dbase_root
-        # NOTE: if using the remote option, don't need to worry about building or
-        # downloading the database
-        if not fiasco.defaults['use_remote_data']:
-            check_database(self.hdf5_dbase_root, **kwargs)
+        check_database(self.hdf5_dbase_root, **kwargs)
 
         # FIXME: this is a bottleneck when creating many ions
         if self.ion_name not in fiasco.list_ions(self.hdf5_dbase_root, sort=False):
-            source = (self.hdf5_dbase_root if not fiasco.defaults['use_remote_data']
-                      else fiasco.defaults['remote_endpoint'])
-            raise MissingIonError(f'{self.ion_name} not found in {source}')
+            raise MissingIonError(f'{self.ion_name} not found in {self.hdf5_dbase_root}')
 
 
 class ContinuumBase(Base):

--- a/fiasco/io/datalayer.py
+++ b/fiasco/io/datalayer.py
@@ -5,14 +5,9 @@ import os
 
 import numpy as np
 import h5py
-try:
-    import h5pyd
-except ImportError:
-    pass
 import astropy.units as u
 from astropy.table import QTable
 
-import fiasco
 from fiasco.util.exceptions import MissingDatabaseError
 
 __all__ = ['DataIndexer']
@@ -24,113 +19,14 @@ class DataIndexer(object):
     """
 
     def __new__(cls, *args):
-        if fiasco.defaults['use_remote_data']:
-            return DataIndexerRemote(
-                fiasco.defaults['remote_domain'], fiasco.defaults['remote_endpoint'], args[1])
-        else:
-            return DataIndexerLocal(*args)
+        return DataIndexerHDF5(*args)
 
     @classmethod
     def create_indexer(cls, *args):
-        if fiasco.defaults['use_remote_data']:
-            return DataIndexerRemote.create_indexer(
-                fiasco.defaults['remote_domain'], fiasco.defaults['remote_endpoint'], args[1])
-        else:
-            return DataIndexerLocal.create_indexer(*args)
+        return DataIndexerHDF5.create_indexer(*args)
 
 
-class DataIndexerRemote(object):
-
-    def __init__(self, domain, endpoint, top_level_path):
-        self.domain = domain
-        self.endpoint = endpoint
-        self.top_level_path = top_level_path
-
-    @classmethod
-    def create_indexer(cls, domain, endpoint, top_level_path):
-        """
-        Create an instance as long as the dataset exists
-        """
-        with h5pyd.File(domain, 'r', endpoint=endpoint) as hf:
-            path_is_valid = True if top_level_path in hf else False
-        return cls(domain, endpoint, top_level_path) if path_is_valid else None
-
-    @property
-    def version(self):
-        with h5pyd.File(self.domain, 'r', endpoint=self.endpoint) as hf:
-            if 'chianti_version' in hf[self.top_level_path].attrs:
-                version = hf[self.top_level_path].attrs['chianti_version']
-            else:
-                version = None
-        return version
-
-    @property
-    def fields(self):
-        with h5pyd.File(self.domain, 'r', endpoint=self.endpoint) as hf:
-            fields = [k for k in hf[self.top_level_path]]
-        return fields
-
-    def as_table(self):
-        qt = QTable()
-        for field in self.fields:
-            qt[field] = self[field]
-        return qt
-
-    def __contains__(self, key):
-        with h5pyd.File(self.domain, 'r', endpoint=self.endpoint) as hf:
-            key_in_grp = key in hf[self.top_level_path]
-        return key_in_grp
-
-    def __getitem__(self, key):
-        """
-        NOTE: There seems to be a weird in bug in h5pyd where if a dataset
-        is returned directly to a numpy array, the slicing/indexing fails. Thus,
-        all of the gymnastics around returning datasets and casting to types appropriately.
-        """
-        if type(key) is int:
-            raise NotImplementedError('Iteration not supported.')
-        with h5pyd.File(self.domain, 'r', endpoint=self.endpoint) as hf:
-            if key not in self:
-                return None
-            ds = hf[self.top_level_path][key]
-            if isinstance(ds, h5pyd.Group):
-                data = DataIndexerRemote.create_indexer(self.domain, self.endpoint,
-                                                        '/'.join([self.top_level_path, key]))
-            else:
-                # Scalars cannot be sliced
-                if not ds.shape:
-                    data = np.array(ds.value)
-                else:
-                    data = ds[:]
-                # Some things are just arrays
-                if ds.attrs['unit'] == 'SKIP' or ds.dtype == 'object':
-                    data = data.astype(ds.dtype)
-                else:
-                    data = u.Quantity(data, ds.attrs['unit'], dtype=ds.dtype)
-                if '|S' in data.dtype.str:
-                    data = data.astype(str)
-        return data
-
-    def __repr__(self):
-        with h5pyd.File(self.domain, 'r', endpoint=self.endpoint) as hf:
-            grp = hf[self.top_level_path]
-            var_names = [key for key in grp]
-            footer = '' if 'footer' not in grp.attrs else grp.attrs['footer']
-
-        name_strs = '\n'.join(var_names)
-        version = '' if self.version is None else f'-- v{self.version}'
-        return f"""{self.top_level_path} {version}
-
-Fields
-------
-{name_strs}
-
-Footer
-------
-{footer}"""
-
-
-class DataIndexerLocal(object):
+class DataIndexerHDF5(object):
     """
     Data access layer for each distinct CHIANTI dataset
 

--- a/fiasco/io/datalayer.py
+++ b/fiasco/io/datalayer.py
@@ -15,7 +15,13 @@ __all__ = ['DataIndexer']
 
 class DataIndexer(object):
     """
-    Data access layer for CHIANTI data
+    Data access layer for each distinct CHIANTI dataset
+
+    Acts as an interface layer between `Ion` and the CHIANTI data. All data that the user interacts
+    with passes through this layer.
+
+    .. warning:: This object is not meant to be instantiated directly by the user. Rather, instances
+                 are created by higher-level objects in order to provide access to the CHIANTI data.
     """
 
     def __new__(cls, *args):
@@ -28,13 +34,7 @@ class DataIndexer(object):
 
 class DataIndexerHDF5(object):
     """
-    Data access layer for each distinct CHIANTI dataset
-
-    Acts as an interface layer between `Ion` and the CHIANTI data stored in the
-    HDF5 database. All data that the user interacts with passes through this layer.
-
-    .. warning:: This object is not meant to be instantiated directly by the user. Rather, instances
-                 are created by higher-level objects in order to provide access to the CHIANTI data.
+    Interface layer for CHIANTI data stored in HDF5 format.
 
     Parameters
     ----------

--- a/fiasco/util/util.py
+++ b/fiasco/util/util.py
@@ -27,14 +27,6 @@ def setup_paths():
         paths['ascii_dbase_root'] = os.path.join(FIASCO_HOME, 'chianti_dbase')
     if 'hdf5_dbase_root' not in paths:
         paths['hdf5_dbase_root'] = os.path.join(FIASCO_HOME, 'chianti_dbase.h5')
-    if 'use_remote_data' not in paths:
-        paths['use_remote_data'] = False
-    else:
-        paths['use_remote_data'] = bool(strtobool(paths['use_remote_data']))
-    # If using remote data, need endpoint and domain
-    if paths['use_remote_data']:
-        assert 'remote_domain' in paths
-        assert 'remote_endpoint' in paths
 
     return paths
 


### PR DESCRIPTION
Fixes #63. This was really just a proof of concept and was not very performant.

I've also renamed `DataIndexerLocal` -> `DataIndexerHDF5`. 

I'd still like to move towards being as agnostic as possible such that one could just write a `DataIndexer*` class and then choose that interface when creating an ion.