### PR TITLE
Speedup listing of all ions in database

### DIFF
--- a/fiasco/fiasco.py
+++ b/fiasco/fiasco.py
@@ -32,21 +32,23 @@ def list_elements(hdf5_dbase_root, sort=True):
     return elements
 
 
-@functools.lru_cache()
+#@functools.lru_cache()
 def list_ions(hdf5_dbase_root, sort=True):
     """
     List all available ions in the CHIANTI database
     """
-    ions = []
-    root = DataIndexer.create_indexer(hdf5_dbase_root, '/')
-    for f in root.fields:
-        try:
-            el = plasmapy.atomic.atomic_symbol(f.capitalize())
-            for i in root[f].fields:
-                if f == i.split('_')[0]:
-                    ions.append(f"{el} {i.split('_')[1]}")
-        except InvalidParticleError:
-            continue
+    root = DataIndexer(hdf5_dbase_root, '/')
+    ions = root['ion_index']
+    if ions is None:
+        ions = []
+        for f in root.fields:
+            try:
+                el = plasmapy.atomic.atomic_symbol(f.capitalize())
+                for i in root[f].fields:
+                    if f == i.split('_')[0]:
+                        ions.append(f"{el} {i.split('_')[1]}")
+            except InvalidParticleError:
+                continue
     # Optional because adds significant overhead
     if sort:
         ions = sorted(ions, key=lambda x: (plasmapy.atomic.atomic_number(x.split()[0]),

--- a/fiasco/fiasco.py
+++ b/fiasco/fiasco.py
@@ -1,7 +1,6 @@
 """
 Package-level functions
 """
-import functools
 import warnings
 
 import numpy as np
@@ -32,12 +31,12 @@ def list_elements(hdf5_dbase_root, sort=True):
     return elements
 
 
-#@functools.lru_cache()
 def list_ions(hdf5_dbase_root, sort=True):
     """
     List all available ions in the CHIANTI database
     """
     root = DataIndexer(hdf5_dbase_root, '/')
+    # NOTE: get the list from the index if possible. This is ~30x faster
     ions = root['ion_index']
     if ions is None:
         ions = []

--- a/fiasco/util/setup_db.py
+++ b/fiasco/util/setup_db.py
@@ -6,6 +6,7 @@ import os
 import warnings
 import tarfile
 
+import numpy as np
 import h5py
 from astropy.config import set_temp_cache
 from astropy.utils.data import download_file
@@ -110,3 +111,8 @@ def build_hdf5_dbase(ascii_dbase_root, hdf5_dbase_root, files=None):
                 else:
                     parser.to_hdf5(hf, df)
                 progress.update()
+            # Build an index for quick lookup of all ions in database
+            from fiasco import list_ions  # import here to avoid circular imports
+            ion_list = list_ions(hdf5_dbase_root)
+            ds = hf.create_dataset('ion_index', data=np.array(ion_list).astype(np.string_))
+            ds.attrs['unit'] = 'SKIP'

--- a/fiasco/util/setup_db.py
+++ b/fiasco/util/setup_db.py
@@ -113,6 +113,9 @@ def build_hdf5_dbase(ascii_dbase_root, hdf5_dbase_root, files=None):
                 progress.update()
             # Build an index for quick lookup of all ions in database
             from fiasco import list_ions  # import here to avoid circular imports
+            # Delete it if it already exists to ensure the index is rebuilt
+            if 'ion_index' in hf:
+                del hf['ion_index']
             ion_list = list_ions(hdf5_dbase_root)
             ds = hf.create_dataset('ion_index', data=np.array(ion_list).astype(np.string_))
             ds.attrs['unit'] = 'SKIP'

--- a/fiasco/util/util.py
+++ b/fiasco/util/util.py
@@ -4,7 +4,6 @@ Basic utilities
 import os
 import sys
 import configparser
-from distutils.util import strtobool
 from builtins import input
 
 FIASCO_HOME = os.path.join(os.environ['HOME'], '.fiasco')


### PR DESCRIPTION
Addresses #69 #73 ping @dstansby 

This adds an `ion_index` entry at the top of the database. `fiasco.list_ions` will then just pull from this rather than searching the entire database tree to create the list.

Some comparisons when creating an `Ion`: 

* original (no index, no cache)
  ```python
  %timeit fiasco.base.IonBase('Fe 18')
  36.3 ms ± 327 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
  ```
* with #69 (i.e. LRU cache)
  ```python
  %timeit fiasco.base.IonBase('Fe 18',)
  113 µs ± 601 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
  ```
* this PR
  ```python
  %timeit fiasco.base.IonBase('Fe 18',)
  1.25 ms ± 4.93 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
  ```

This is ~30x faster than the original method, but still about ~10x slower than the cache method. However, I can still create a collection of every ion in the database in <1 s using this PR so I'm not sure that further optimization is that necessary?

