### PR TITLE
Make sure pytest is the right version on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
     - pip install -r requirements/requirements-dev.txt
     - pip install --upgrade numpy>=1.16
     - pip install --upgrade attrs>=19.2.0
+    - pip install --upgrade pytest>=4.6
 script: python setup.py $SETUP_CMD
 env: SETUP_CMD='test'
 


### PR DESCRIPTION
This pins pytest to at least 4.6 on Travis. There is already a version installed in the python images and on 3.6 and 3.7, it is too old.