### PR TITLE
Default to normal database for test database

### DIFF
--- a/fiasco/util/util.py
+++ b/fiasco/util/util.py
@@ -26,6 +26,9 @@ def setup_paths():
         paths['ascii_dbase_root'] = os.path.join(FIASCO_HOME, 'chianti_dbase')
     if 'hdf5_dbase_root' not in paths:
         paths['hdf5_dbase_root'] = os.path.join(FIASCO_HOME, 'chianti_dbase.h5')
+    if 'test_ascii_dbase_root' not in paths:
+        # Use the usual chianti database by default
+        paths['test_ascii_dbase_root'] = os.path.join(FIASCO_HOME, 'chianti_dbase')
 
     return paths
 


### PR DESCRIPTION
If `test_ascii_dbase_root` isn't set in the config file, default to the normal database. This way the files automatically get picked up, but the test database can still be configured to another database if desired by setting it in the fiascorc file.