### PR TITLE
Adding support for roman numerals

### DIFF
--- a/fiasco/base.py
+++ b/fiasco/base.py
@@ -23,11 +23,10 @@ class Base(object):
         self._element, ion = ion_name.split()
         if '+' in ion:
             ion = f"{int(ion.strip('+')) + 1}"
-        if roman.is_roman_numeral(ion):
-            ion = roman.from_roman(ion)
+        if roman.is_roman_numeral(ion.upper()):
+            ion = roman.from_roman(ion.upper())
         self.ionization_stage = int(ion)
         self.charge_state = self.ionization_stage - 1
-        self.roman_symbol = roman.to_roman(int(ion))
         if hdf5_dbase_root is None:
             self.hdf5_dbase_root = fiasco.defaults['hdf5_dbase_root']
         else:
@@ -57,6 +56,13 @@ class Base(object):
         # Old CHIANTI format, only preserved for internal data access
         return f'{self.atomic_symbol.lower()}_{self.ionization_stage}'
 
+    @property
+    def roman_numeral(self):
+        return roman.to_roman(int(self.ionization_stage))
+
+    @property
+    def roman_name(self):
+        return f'{self.atomic_symbol} {self.roman_numeral}'
 
 class ContinuumBase(Base):
     """

--- a/fiasco/base.py
+++ b/fiasco/base.py
@@ -2,6 +2,7 @@
 Base classes for access to CHIANTI ion data
 """
 import plasmapy.particles
+from plasmapy.utils import roman
 
 import fiasco
 from .io.factory import all_subclasses
@@ -22,8 +23,11 @@ class Base(object):
         self._element, ion = ion_name.split()
         if '+' in ion:
             ion = f"{int(ion.strip('+')) + 1}"
+        if roman.is_roman_numeral(ion):
+            ion = roman.from_roman(ion)
         self.ionization_stage = int(ion)
         self.charge_state = self.ionization_stage - 1
+        self.roman_symbol = roman.to_roman(int(ion))
         if hdf5_dbase_root is None:
             self.hdf5_dbase_root = fiasco.defaults['hdf5_dbase_root']
         else:

--- a/fiasco/tests/test_base.py
+++ b/fiasco/tests/test_base.py
@@ -86,7 +86,7 @@ def test_create_ion_input_formats(hdf5_dbase_root):
         assert ion.ionization_stage == 21
         assert ion.charge_state == 20
         assert ion._ion_name == 'fe_21'
-        assert ion._name == 'Fe XXI'
+        assert ion.roman_name == 'Fe XXI'
         assert ion.roman_numeral == 'XXI'
 
 def test_create_invalid_ion_raises_missing_ion_error(hdf5_dbase_root):

--- a/fiasco/tests/test_base.py
+++ b/fiasco/tests/test_base.py
@@ -76,18 +76,24 @@ def test_create_ion_element_name(hdf5_dbase_root):
     assert ion.charge_state == 0
     assert ion._ion_name == 'h_1'
 
-def test_create_ion_input_formats(hdf5_dbase_root):
-    ion_names = ["Iron 21", "iron XXI", "Fe xxi", "Fe 20+"]
-    for input_name in ion_names:
-        ion = fiasco.base.IonBase(input_name, hdf5_dbase_root=hdf5_dbase_root)
-        assert ion.element_name == 'iron'
-        assert ion.atomic_symbol == 'Fe'
-        assert ion.atomic_number == 26
-        assert ion.ionization_stage == 21
-        assert ion.charge_state == 20
-        assert ion._ion_name == 'fe_21'
-        assert ion.roman_name == 'Fe XXI'
-        assert ion.roman_numeral == 'XXI'
+
+@pytest.mark.parametrize('ion_name', [
+    "Iron 21",
+    "iron XXI",
+    "Fe xxi",
+    "Fe 20+",
+])
+def test_create_ion_input_formats(hdf5_dbase_root, ion_name):
+    ion = fiasco.base.IonBase(ion_name, hdf5_dbase_root=hdf5_dbase_root)
+    assert ion.element_name == 'iron'
+    assert ion.atomic_symbol == 'Fe'
+    assert ion.atomic_number == 26
+    assert ion.ionization_stage == 21
+    assert ion.charge_state == 20
+    assert ion._ion_name == 'fe_21'
+    assert ion.roman_name == 'Fe XXI'
+    assert ion.roman_numeral == 'XXI'
+
 
 def test_create_invalid_ion_raises_missing_ion_error(hdf5_dbase_root):
     with pytest.raises(MissingIonError):

--- a/fiasco/tests/test_base.py
+++ b/fiasco/tests/test_base.py
@@ -76,6 +76,18 @@ def test_create_ion_element_name(hdf5_dbase_root):
     assert ion.charge_state == 0
     assert ion._ion_name == 'h_1'
 
+def test_create_ion_input_formats(hdf5_dbase_root):
+    ion_names = ["Iron 21", "iron XXI", "Fe xxi", "Fe 20+"]
+    for input_name in ion_names:
+        ion = fiasco.base.IonBase(input_name, hdf5_dbase_root=hdf5_dbase_root)
+        assert ion.element_name == 'iron'
+        assert ion.atomic_symbol == 'Fe'
+        assert ion.atomic_number == 26
+        assert ion.ionization_stage == 21
+        assert ion.charge_state == 20
+        assert ion._ion_name == 'fe_21'
+        assert ion._name == 'Fe XXI'
+        assert ion.roman_numeral == 'XXI'
 
 def test_create_invalid_ion_raises_missing_ion_error(hdf5_dbase_root):
     with pytest.raises(MissingIonError):

--- a/fiasco/tests/test_base.py
+++ b/fiasco/tests/test_base.py
@@ -7,77 +7,9 @@ import fiasco
 from fiasco.util.exceptions import MissingIonError
 
 
-@pytest.fixture
-def ionbase(hdf5_dbase_root):
-    return fiasco.base.IonBase('fe 5', hdf5_dbase_root=hdf5_dbase_root)
-
-
-def test_ion_name(ionbase):
-    assert ionbase.ion_name == 'Fe 5'
-    assert ionbase._ion_name == 'fe_5'
-
-
-def test_atomic_symbol(ionbase):
-    assert ionbase.atomic_symbol == 'Fe'
-
-
-def test_atomic_number(ionbase):
-    assert ionbase.atomic_number == 26
-
-
-def test_element_name(ionbase):
-    assert ionbase.element_name == 'iron'
-
-
-def test_ionization_stage(ionbase):
-    assert ionbase.ionization_stage == 5
-
-
-def test_charge_state(ionbase):
-    assert ionbase.charge_state == 4
-
-
-def test_create_ion_symbol_lower(hdf5_dbase_root):
-    ion = fiasco.base.IonBase('h 1', hdf5_dbase_root=hdf5_dbase_root)
-    assert ion.element_name == 'hydrogen'
-    assert ion.atomic_symbol == 'H'
-    assert ion.atomic_number == 1
-    assert ion.ionization_stage == 1
-    assert ion.charge_state == 0
-    assert ion._ion_name == 'h_1'
-
-
-def test_create_ion_symbol_upper(hdf5_dbase_root):
-    ion = fiasco.base.IonBase('H 1', hdf5_dbase_root=hdf5_dbase_root)
-    assert ion.element_name == 'hydrogen'
-    assert ion.atomic_symbol == 'H'
-    assert ion.atomic_number == 1
-    assert ion.ionization_stage == 1
-    assert ion.charge_state == 0
-    assert ion._ion_name == 'h_1'
-
-
-def test_create_ion_charge_state(hdf5_dbase_root):
-    ion = fiasco.base.IonBase('h +0', hdf5_dbase_root=hdf5_dbase_root)
-    assert ion.element_name == 'hydrogen'
-    assert ion.atomic_symbol == 'H'
-    assert ion.atomic_number == 1
-    assert ion.ionization_stage == 1
-    assert ion.charge_state == 0
-    assert ion._ion_name == 'h_1'
-
-
-def test_create_ion_element_name(hdf5_dbase_root):
-    ion = fiasco.base.IonBase('hydrogen 1', hdf5_dbase_root=hdf5_dbase_root)
-    assert ion.element_name == 'hydrogen'
-    assert ion.atomic_symbol == 'H'
-    assert ion.atomic_number == 1
-    assert ion.ionization_stage == 1
-    assert ion.charge_state == 0
-    assert ion._ion_name == 'h_1'
-
-
 @pytest.mark.parametrize('ion_name', [
+    "fe 21",
+    "Fe 21",
     "Iron 21",
     "iron XXI",
     "Fe xxi",


### PR DESCRIPTION
Fixes #19 

Creation of ion objects can now take roman numerals e.g.:

```python
>>> from fiasco.ion import IonBase
>>> ion = IonBase("Fe XXI")
>>> ion.ion_name
"Fe 21"
```

Similarly, ion objects now have a roman_symbol attribute 
```python
>>> ion = IonBase("Fe XXI")
>>> ion.roman_symbol
"XXI"
>>> ion = IonBase("Fe 21")
>>> ion.roman_symbol
"XXI"
```