### PR TITLE
Don't default to None in required datasets decorator

### DIFF
--- a/fiasco/fiasco.py
+++ b/fiasco/fiasco.py
@@ -37,8 +37,9 @@ def list_ions(hdf5_dbase_root, sort=True):
     """
     root = DataIndexer(hdf5_dbase_root, '/')
     # NOTE: get the list from the index if possible. This is ~30x faster
-    ions = root['ion_index']
-    if ions is None:
+    try:
+        ions = root['ion_index']
+    except KeyError:
         ions = []
         for f in root.fields:
             try:

--- a/fiasco/io/datalayer.py
+++ b/fiasco/io/datalayer.py
@@ -56,8 +56,11 @@ class DataIndexerHDF5(object):
         if not os.path.isfile(hdf5_path):
             raise MissingDatabaseError(f'No HDF5 database found at {hdf5_path}')
         with h5py.File(hdf5_path, 'r') as hf:
-            path_is_valid = True if top_level_path in hf else False
-        return cls(hdf5_path, top_level_path) if path_is_valid else None
+            path_is_valid = top_level_path in hf
+        if path_is_valid:
+            return cls(hdf5_path, top_level_path)
+        else:
+            raise KeyError(f'{top_level_path} not found in {hdf5_path}')
 
     @property
     def version(self):
@@ -98,7 +101,7 @@ class DataIndexerHDF5(object):
         if type(key) is int:
             raise NotImplementedError('Iteration not supported.')
         if key not in self:
-            return None
+            raise KeyError(f'{key} not found in {self.top_level_path}')
         with h5py.File(self.hdf5_dbase_root, 'r') as hf:
             ds = hf[self.top_level_path][key]
             if isinstance(ds, h5py.Group):

--- a/fiasco/ion.py
+++ b/fiasco/ion.py
@@ -209,7 +209,7 @@ Using Datasets:
 
             C^e_{ij} = \\frac{\omega_j}{\omega_i}C^d_{ji}e^{-k_BT_e/\Delta E_{ij}}
 
-        where :math:`j,i` are the upper and lower level indices, respectively, :math:`\omega_j,\omega_i` 
+        where :math:`j,i` are the upper and lower level indices, respectively, :math:`\omega_j,\omega_i`
         are the statistical weights of the upper and lower levels, respectively, and :math:`\Delta E_{ij}`
         is the energy of the transition.
 
@@ -479,8 +479,6 @@ Using Datasets:
         kBT = const.k_B*self.temperature
         energy = np.outer(xgl, kBT) + self.ip
         cross_section = self.direct_ionization_cross_section(energy)
-        if cross_section is None:
-            return None
         term1 = np.sqrt(8./np.pi/const.m_e)*np.sqrt(kBT)*np.exp(-self.ip/kBT)
         term2 = ((wgl*xgl)[:, np.newaxis]*cross_section).sum(axis=0)
         term3 = (wgl[:, np.newaxis]*cross_section).sum(axis=0)*self.ip/kBT
@@ -599,9 +597,7 @@ Using Datasets:
         excitation_autoionization_rate
         """
         di_rate = self.direct_ionization_rate()
-        di_rate = np.zeros(self.temperature.shape)*u.cm**3/u.s if di_rate is None else di_rate
         ea_rate = self.excitation_autoionization_rate()
-        ea_rate = np.zeros(self.temperature.shape)*u.cm**3/u.s if ea_rate is None else ea_rate
         return di_rate + ea_rate
 
     @needs_dataset('rrparams')
@@ -678,9 +674,7 @@ Using Datasets:
         dielectronic_recombination_rate
         """
         rr_rate = self.radiative_recombination_rate()
-        rr_rate = np.zeros(self.temperature.shape)*u.cm**3/u.s if rr_rate is None else rr_rate
         dr_rate = self.dielectronic_recombination_rate()
-        dr_rate = np.zeros(self.temperature.shape)*u.cm**3/u.s if dr_rate is None else dr_rate
         return rr_rate + dr_rate
 
     @u.quantity_input

--- a/fiasco/ion.py
+++ b/fiasco/ion.py
@@ -13,6 +13,7 @@ from .level import Level, Transitions
 from fiasco import proton_electron_ratio
 from fiasco.util import (needs_dataset, vectorize_where, vectorize_where_sum,
                          burgess_tully_descale)
+from fiasco.util.exceptions import MissingDatasetException
 
 __all__ = ['Ion']
 
@@ -75,11 +76,14 @@ Using Datasets:
   ip: {self._dset_names['ip_filename']}"""
 
     def __getitem__(self, key):
-        if self._elvlc is None:
+        try:
+            _ = self._elvlc
+        except KeyError:
             raise IndexError(f'No energy levels available for {self.ion_name}')
-        # Throw an index error to stop iteration
-        _ = self._elvlc['level'][key]
-        return Level(key, self._elvlc)
+        else:
+            # Throw an index error to stop iteration
+            _ = self._elvlc['level'][key]
+            return Level(key, self._elvlc)
 
     def __add__(self, value):
         return IonCollection(self, value)
@@ -282,6 +286,13 @@ Using Datasets:
             temperatures, ``m`` is the number of densities, and ``n``
             is the number of energy levels.
         """
+        # NOTE: Cannot include protons if psplups data not available
+        try:
+            _ = self._psplups
+        except KeyError:
+            # TODO: log this
+            include_protons = False
+
         level = self._elvlc['level']
         lower_level = self._scups['lower_level']
         upper_level = self._scups['upper_level']
@@ -302,7 +313,7 @@ Using Datasets:
         dex_diagonal_e = vectorize_where_sum(
             upper_level, level, dex_rate_e.value.T, 0).T * dex_rate_e.unit
         # Collisional--protons
-        if include_protons and self._psplups is not None:
+        if include_protons:
             lower_level_p = self._psplups['lower_level']
             upper_level_p = self._psplups['upper_level']
             pe_ratio = proton_electron_ratio(self.temperature,
@@ -349,7 +360,7 @@ Using Datasets:
 
         return u.Quantity(populations)
 
-    @needs_dataset('scups', 'elvlc', 'wgfa')
+    @needs_dataset('abundance', 'elvlc')
     @u.quantity_input
     def contribution_function(self, density: u.cm**(-3), **kwargs) -> u.cm**3 * u.erg / u.s:
         """
@@ -391,7 +402,6 @@ Using Datasets:
         g = term[:, :, np.newaxis] * populations[:, :, i_upper] * (A * energy)
         return g
 
-    @needs_dataset('scups', 'elvlc', 'wgfa')
     @u.quantity_input
     def emissivity(self, density: u.cm**(-3), **kwargs) -> u.erg * u.cm**(-3) / u.s:
         """
@@ -418,7 +428,6 @@ Using Datasets:
         g = self.contribution_function(density, **kwargs)
         return g * (density**2)[np.newaxis, :, np.newaxis]
 
-    @needs_dataset('scups', 'elvlc', 'wgfa')
     @u.quantity_input
     def intensity(self,
                   density: u.cm**(-3),
@@ -596,8 +605,14 @@ Using Datasets:
         direct_ionization_rate
         excitation_autoionization_rate
         """
-        di_rate = self.direct_ionization_rate()
-        ea_rate = self.excitation_autoionization_rate()
+        try:
+            di_rate = self.direct_ionization_rate()
+        except MissingDatasetException:
+            di_rate = u.Quantity(np.zeros(self.temperature.shape), 'cm3 s-1')
+        try:
+            ea_rate = self.excitation_autoionization_rate()
+        except MissingDatasetException:
+            ea_rate = u.Quantity(np.zeros(self.temperature.shape), 'cm3 s-1')
         return di_rate + ea_rate
 
     @needs_dataset('rrparams')
@@ -673,8 +688,14 @@ Using Datasets:
         radiative_recombination_rate
         dielectronic_recombination_rate
         """
-        rr_rate = self.radiative_recombination_rate()
-        dr_rate = self.dielectronic_recombination_rate()
+        try:
+            rr_rate = self.radiative_recombination_rate()
+        except MissingDatasetException:
+            rr_rate = u.Quantity(np.zeros(self.temperature.shape), 'cm3 s-1')
+        try:
+            dr_rate = self.dielectronic_recombination_rate()
+        except MissingDatasetException:
+            dr_rate = u.Quantity(np.zeros(self.temperature.shape), 'cm3 s-1')
         return rr_rate + dr_rate
 
     @u.quantity_input
@@ -722,7 +743,10 @@ Using Datasets:
             const.h*(const.c**3) * (const.m_e * const.k_B)**(3/2)))
         recombining = Ion(f'{self.element_name} {self.ionization_stage + 1}', self.temperature,
                           **self._dset_names)
-        omega_0 = 1. if recombining._fblvl is None else recombining._fblvl['multiplicity'][0]
+        try:
+            omega_0 = recombining._fblvl['multiplicity'][0]
+        except MissingDatasetException:
+            omega_0 = 1.0
         E_photon = const.h * const.c / wavelength
         energy_temperature_factor = np.outer(self.temperature**(-3/2), E_photon**5)
         # Sum over levels of recombined ion
@@ -780,6 +804,7 @@ Using Datasets:
 
         return gf
 
+    @needs_dataset('itoh')
     @u.quantity_input
     def _gaunt_factor_free_free_itoh(self, wavelength: u.angstrom) -> u.dimensionless_unscaled:
         """
@@ -816,6 +841,7 @@ Using Datasets:
 
         return gf
 
+    @needs_dataset('gffgu')
     @u.quantity_input
     def _gaunt_factor_free_free_sutherland(self,
                                            wavelength: u.angstrom) -> u.dimensionless_unscaled:
@@ -872,6 +898,7 @@ Using Datasets:
         return np.where(energy < self._verner['E_thresh'], 0.,
                         F.decompose().value) * self._verner['sigma_0']
 
+    @needs_dataset('klgfb')
     @u.quantity_input
     def _karzas_cross_section(self,
                               photon_energy: u.erg,

--- a/fiasco/tests/test_ion.py
+++ b/fiasco/tests/test_ion.py
@@ -6,6 +6,7 @@ import astropy.units as u
 import pytest
 
 import fiasco
+from fiasco.util.exceptions import MissingDatasetException
 
 temperature = np.logspace(5, 8, 100)*u.K
 
@@ -18,6 +19,7 @@ def ion(hdf5_dbase_root):
 @pytest.fixture
 def another_ion(hdf5_dbase_root):
     return fiasco.Ion('Fe 6', temperature, hdf5_dbase_root=hdf5_dbase_root)
+
 
 @pytest.fixture
 def fe10(hdf5_dbase_root):
@@ -35,11 +37,13 @@ def test_repr(ion):
 def test_repr_scalar_temp(ion, hdf5_dbase_root):
     assert 'Fe 5' in fiasco.Ion('Fe 5', 1e6 * u.K, hdf5_dbase_root=hdf5_dbase_root).__repr__()
 
+
 def test_ion_properties(ion):
     assert ion.atomic_number == 26
     assert ion.element_name == 'iron'
     assert ion.atomic_symbol == 'Fe'
     assert ion.ion_name == 'Fe 5'
+
 
 def test_level_properties(ion):
     assert hasattr(ion[0], 'level')
@@ -99,7 +103,8 @@ def test_missing_abundance(hdf5_dbase_root):
                      temperature,
                      abundance_filename='sun_coronal_1992_feldman',
                      hdf5_dbase_root=hdf5_dbase_root)
-    assert ion.abundance is None
+    with pytest.raises(KeyError):
+        _ = ion.abundance
 
 
 def test_ip(ion):
@@ -110,7 +115,8 @@ def test_ip(ion):
 
 def test_missing_ip(hdf5_dbase_root):
     ion = fiasco.Ion('Fe 27', temperature, hdf5_dbase_root=hdf5_dbase_root)
-    assert ion.ip is None
+    with pytest.raises(MissingDatasetException):
+        _ = ion.ip
 
 
 def test_contribution_function(ion):

--- a/fiasco/util/decorators.py
+++ b/fiasco/util/decorators.py
@@ -3,7 +3,7 @@ Useful function/method decorators
 """
 from functools import wraps
 
-from fiasco.util import MissingDatasetException
+from fiasco.util.exceptions import MissingDatasetException
 
 __all__ = ['needs_dataset']
 
@@ -22,9 +22,11 @@ def needs_dataset(*names):
         @wraps(func)
         def func_wrapper(*args, **kwargs):
             ion = args[0]
-            missing = [n for n in names if ion.__getattribute__(n) is None]
-            if len(missing):
-                raise MissingDatasetException(f'Missing {missing} files for {ion.ion_name}.')
+            for n in names:
+                try:
+                    _ = ion.__getattribute__(n)
+                except KeyError:
+                    raise MissingDatasetException(f'{n} dataset missing for {ion.ion_name}.')
 
             return func(*args, **kwargs)
         return func_wrapper

--- a/fiasco/util/decorators.py
+++ b/fiasco/util/decorators.py
@@ -3,22 +3,29 @@ Useful function/method decorators
 """
 from functools import wraps
 
+from fiasco.util import MissingDatasetException
+
 __all__ = ['needs_dataset']
 
 
-def needs_dataset(*names, default=None):
+def needs_dataset(*names):
     """
-    Decorator for skipping methods when the needed atomic data is not available
+    Decorator for raising an error when the needed atomic data is not available.
     """
     non_ion_datasets = ['abundance', 'ioneq']
     names = [f'_{n}' if n not in non_ion_datasets else f'{n}' for n in names]
 
     def decorator(func):
+        """
+        func is a method of `fiasco.ion.Ion`.
+        """
         @wraps(func)
         def func_wrapper(*args, **kwargs):
-            if any([args[0].__getattribute__(n) is None for n in names]):
-                return default
-            else:
-                return func(*args, **kwargs)
+            ion = args[0]
+            missing = [n for n in names if ion.__getattribute__(n) is None]
+            if len(missing):
+                raise MissingDatasetException(f'Missing {missing} files for {ion.ion_name}.')
+
+            return func(*args, **kwargs)
         return func_wrapper
     return decorator

--- a/fiasco/util/exceptions.py
+++ b/fiasco/util/exceptions.py
@@ -21,3 +21,8 @@ class MissingASCIIFileError(Exception):
     An error to raise when one of the CHIANTI ASCII files cannot
     be found.
     """
+
+class MissingDatasetException(Exception):
+    """
+    An error to raise when a dataset file is missing.
+    """

--- a/fiasco/util/exceptions.py
+++ b/fiasco/util/exceptions.py
@@ -22,6 +22,7 @@ class MissingASCIIFileError(Exception):
     be found.
     """
 
+
 class MissingDatasetException(Exception):
     """
     An error to raise when a dataset file is missing.


### PR DESCRIPTION
Fixes #93 , Fixes #89 

Returning `None` here is wild, and just leads to very confusing error messages down the line. It's especially wild in a decorator. Given the `default` argument isn't used anywhere, remove this, and error if any of the datasets aren't present.

Could perhaps have a nicer error message with the ion name in it?