### PR TITLE
Add level populations test with protons

### DIFF
--- a/fiasco/conftest.py
+++ b/fiasco/conftest.py
@@ -1,0 +1,80 @@
+# this contains imports plugins that configure py.test for astropy tests.
+# by importing them here in conftest.py they are discoverable by py.test
+# no matter how it is invoked within the source tree.
+import os
+import pytest
+from astropy.tests.plugins import *
+
+import fiasco
+from fiasco.util import build_hdf5_dbase, download_dbase
+from fiasco.util.setup_db import CHIANTI_URL, LATEST_VERSION, FIASCO_HOME
+
+# Minimal set of CHIANTI files needed to run the tests
+TEST_FILES = {
+    'sun_photospheric_1998_grevesse.abund': '9b175ee91f80fbe01967321a0fb051a8',
+    'chianti.ip':                           'a5a5071535f14590210957f8783f2843',
+    'chianti.ioneq':                        '81d8d24bb09cb2da63befd30e6c8767c',
+    'gffgu.dat':                            '5895e1f211e7baa8293478df014b9ff1',
+    'gffint.dat':                           '96381825257793805ca42eba03ae83e2',
+    'klgfb.dat':                            '5496daa096dd4f7b935ec0d0e6417084',
+    'itoh.dat':                             'e40aacc9d06889f9c4ba63a92673a398',
+    'hseq_2photon.dat':                     '48656984fbcbe38f883ff9a4460c790a',
+    'heseq_2photon.dat':                    '9e42ac8c37d67ba3109aaa56aab9e736',
+    'verner_short.txt':                     'f05296ffc9c5306846ac9caf136fad26',
+
+    'h_1.elvlc':                            'd31620aaf26a14486e635d14bcf7a6c1',
+    'h_1.wgfa':                             'ed2a561ecdba5ee4b05ea56c297724ba',
+    'h_1.scups':                            'de180c9e1b4f50a503efad8c83e714ab',
+    'h_1.diparams':                         'f9be79794cc092c75733ece7aba9f29f',
+    'h_2.rrparams':                         '05eb5044dc1ad070338d1ba3745dc4de',
+    'he_1.elvlc':                           '577245da46cfc4d27a05f40147f17610',
+    'he_2.elvlc':                           '58eee740f6842850f1f35a4f95b3e12c',
+    'he_3.rrparams':                        '67e2e7a5e86c8eaa5db4e95ac3d35989',
+    'li_1.diparams':                        '2a4b60bc799a1ea3ee3e911b5968733e',
+    'ca_2.elvlc':                           'c8a9dbdc622d0a15eea6cf0eb1631d3b',
+    'fe_2.elvlc':                           '9306d594a66b4649363a778a650853f9',
+
+    'fe_5.elvlc':                           'f7dd75c6bcea77584c5e00ddf2684d9c',
+    'fe_5.fblvl':                           'e13a9becff489ea044fbd3cb1e02af13',
+    'fe_5.drparams':                        '0f47e2fbf4be9eb5564a8adc19531999',
+    'fe_5.easplups':                        'ec5443d429722ccdd9903743ca4718ab',
+    'fe_5.scups':                           '0a863212d59c5eda5936e0664b513fb9',
+    'fe_5.wgfa':                            '6f8e4d41760d5a0540008e15aca1038c',
+
+    'fe_6.elvlc':                           '081519f986b8a8ed99a34ecf813f1358',
+    'fe_9.elvlc':                           'b7d04f65a87a8de1c2bfc77331e438f3',
+    'fe_12.elvlc':                          'ee9beb8b2ff03ba8fc046bd722992b21',
+    'fe_15.elvlc':                          'cb8e6291bac17325130ea8564e118d48',
+    'fe_18.rrparams':                       '6a36e5db1e377d0c30652960eb77b93d',
+    'fe_18.drparams':                       '1e8b0194aeb099b2653508110e388200',
+    'fe_27.rrparams':                       '75383b0f1b167f862cfd26bbadd2a029',
+    'fe_10.elvlc':                          'f221d4c7167336556d57378ac368afc1',
+
+    # Used to test level populations with protons included
+    # (ie. needs a psplups file)
+    'mg_5.psplups':                         'f5c6bc5a6ccd801cce4713e04b0c65c1',
+    'mg_5.wgfa':                            'f023b9a5006962c4bda44121fc53ed45',
+    'mg_5.elvlc':                           '7303f9b5f7247650cff7e84917e7cb8d',
+    'mg_5.scups':                           '2a59c5646660088f41f893c0384f8584',
+
+}
+
+
+@pytest.fixture(scope='session')
+def ascii_dbase_root(tmpdir_factory):
+    # If we already have a local copy, just return the path to that
+    path = fiasco.defaults.get('test_ascii_dbase_root')
+    if path is not None and os.path.exists(path):
+        return path
+
+    # Otherwise download the database
+    path = tmpdir_factory.mktemp('chianti_dbase')
+    download_dbase(CHIANTI_URL.format(version=LATEST_VERSION), path)
+    return path
+
+
+@pytest.fixture(scope='session')
+def hdf5_dbase_root(ascii_dbase_root, tmpdir_factory):
+    path = tmpdir_factory.mktemp('fiasco').join('chianti_dbase.h5')
+    build_hdf5_dbase(ascii_dbase_root, path, files=TEST_FILES)
+    return path

--- a/fiasco/tests/test_ion.py
+++ b/fiasco/tests/test_ion.py
@@ -22,8 +22,8 @@ def another_ion(hdf5_dbase_root):
 
 
 @pytest.fixture
-def fe10(hdf5_dbase_root):
-    return fiasco.Ion('Fe 10', temperature, hdf5_dbase_root=hdf5_dbase_root)
+def mg5(hdf5_dbase_root):
+    return fiasco.Ion('Mg 5', temperature, hdf5_dbase_root=hdf5_dbase_root)
 
 
 def test_level_indexing(ion):
@@ -61,12 +61,14 @@ def test_scalar_temperature(hdf5_dbase_root):
     np.testing.assert_allclose(ioneq, ioneq_data[i_t])
 
 
-def test_scalar_density(hdf5_dbase_root):
-    ion = fiasco.Ion('H 1', temperature, hdf5_dbase_root=hdf5_dbase_root)
-    pop = ion.level_populations(1e8 * u.cm**-3)
+@pytest.mark.parametrize('include_protons, val', [[True, 0.5562662264406345],
+                                                  [False, 0.5564759123266327]])
+def test_level_populations(hdf5_dbase_root, include_protons, val):
+    ion = fiasco.Ion('Mg 5', temperature, hdf5_dbase_root=hdf5_dbase_root)
+    pop = ion.level_populations(1e8 * u.cm**-3, include_protons=include_protons)
     assert pop.shape == ion.temperature.shape + (1,) + ion._elvlc['level'].shape
     # This value has not been checked for correctness
-    np.testing.assert_allclose(pop[0, 0, 0], 0.9965048292729177)
+    np.testing.assert_allclose(pop[0, 0, 0], val)
 
 
 def test_no_elvlc_raises_index_error(hdf5_dbase_root):
@@ -94,12 +96,12 @@ def test_abundance(ion):
     np.testing.assert_allclose(ion.abundance, 3.1622776601683795e-05)
 
 
-def test_proton_collision(fe10):
-    rate = fe10.proton_collision_excitation_rate()
-    assert u.allclose(rate[0, 0], 4.69587161e-13 * u.cm**3 / u.s)
+def test_proton_collision(mg5):
+    rate = mg5.proton_collision_excitation_rate()
+    assert u.allclose(rate[0, 0], 5.21207938e-11 * u.cm**3 / u.s)
 
-    rate = fe10.proton_collision_deexcitation_rate()
-    assert u.allclose(rate[0, 0], 1.17688025e-12 * u.cm**3 / u.s)
+    rate = mg5.proton_collision_deexcitation_rate()
+    assert u.allclose(rate[0, 0], 8.91255746e-11 * u.cm**3 / u.s)
 
 
 def test_missing_abundance(hdf5_dbase_root):

--- a/fiasco/util/setup_db.py
+++ b/fiasco/util/setup_db.py
@@ -18,7 +18,7 @@ from .util import get_masterlist, query_yes_no
 from .exceptions import MissingASCIIFileError
 
 FIASCO_HOME = os.path.join(os.environ['HOME'], '.fiasco')
-CHIANTI_URL = 'http://www.chiantidatabase.org/download/CHIANTI_{version}_data.tar.gz'
+CHIANTI_URL = 'http://download.chiantidatabase.org/CHIANTI_v{version}_database.tar.gz'
 LATEST_VERSION = '8.0.7'
 
 __all__ = ['check_database', 'download_dbase', 'build_hdf5_dbase']


### PR DESCRIPTION
Should add a bit more coverage. I had to add a new ion to the test database as it needed a `psplups` file, but I removed the `fe_10.psplups` one as I think that was only there for testing the parser.