### PR TITLE
Better indexing for IonCollection

### DIFF
--- a/fiasco/collections.py
+++ b/fiasco/collections.py
@@ -39,7 +39,11 @@ class IonCollection(object):
             'Temperatures for all ions in collection must be the same.')
 
     def __getitem__(self, value):
-        return self._ion_list[value]
+        ions = self._ion_list[value]
+        if isinstance(ions, list):
+            return IonCollection(*ions)
+        else:
+            return ions
 
     def __contains__(self, value):
         if type(value) is str:

--- a/fiasco/tests/test_collections.py
+++ b/fiasco/tests/test_collections.py
@@ -56,10 +56,15 @@ def test_create_collection_from_collection(collection):
     assert isinstance(fiasco.IonCollection(collection), fiasco.IonCollection)
 
 
-def test_getitem(ion, another_ion):
-    collection = fiasco.IonCollection(ion, another_ion)
+def test_getitem(ion, another_ion, element, another_element):
+    collection = fiasco.IonCollection(ion, another_ion, element, another_element)
     assert collection[0] == ion
     assert collection[1] == another_ion
+    assert isinstance(collection[1:2], fiasco.IonCollection)
+    assert collection[1:2][0] == another_ion
+    assert isinstance(collection[:2], fiasco.IonCollection)
+    for i in collection:
+        assert isinstance(i, fiasco.Ion)
 
 
 def test_contains(collection, hdf5_dbase_root):

--- a/fiasco/tests/test_element.py
+++ b/fiasco/tests/test_element.py
@@ -45,37 +45,12 @@ def test_radd_elements(element, another_element):
     assert collection[0].ion_name == another_element[0].ion_name
 
 
-def test_create_element_number(element, hdf5_dbase_root):
-    other_element = fiasco.Element(element.atomic_number,
-                                   temperature,
-                                   hdf5_dbase_root=hdf5_dbase_root)
-    for ion in other_element:
-        assert ion in element
-    assert other_element.atomic_symbol == element.atomic_symbol
-    assert other_element.atomic_number == element.atomic_number
-    assert other_element.element_name == element.element_name
-
-
-def test_create_element_name(element, hdf5_dbase_root):
-    other_element = fiasco.Element(element.element_name,
-                                   temperature,
-                                   hdf5_dbase_root=hdf5_dbase_root)
-    for ion in other_element:
-        assert ion in element
-    assert other_element.atomic_symbol == element.atomic_symbol
-    assert other_element.atomic_number == element.atomic_number
-    assert other_element.element_name == element.element_name
-
-
-def test_create_element_lowercase(element, hdf5_dbase_root):
-    other_element = fiasco.Element(element.atomic_symbol.lower(),
-                                   temperature,
-                                   hdf5_dbase_root=hdf5_dbase_root)
-    for ion in other_element:
-        assert ion in element
-    assert other_element.atomic_symbol == element.atomic_symbol
-    assert other_element.atomic_number == element.atomic_number
-    assert other_element.element_name == element.element_name
+@pytest.mark.parametrize('symbol', [1, 'hydrogen', 'Hydrogen', 'H'])
+def test_create_element_number(symbol, hdf5_dbase_root):
+    other_element = fiasco.Element(symbol, temperature, hdf5_dbase_root=hdf5_dbase_root)
+    assert other_element.atomic_symbol == 'H'
+    assert other_element.atomic_number == 1
+    assert other_element.element_name == 'hydrogen'
 
 
 def test_getitem_ion_name(element):


### PR DESCRIPTION
`collection[:2]` now yields a collection, not a list of `Ion` objects. 