### PR TITLE
Add example for computing non-equilibrium ion populations

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -12,6 +12,34 @@
   abstract = {We have calculated partial final-state resolved radiative recombination (RR) rate coefficients from the initial ground and metastable levels of all elements up to and including Zn, plus Kr, Mo, and Xe, for all isoelectronic sequences up to Na-like forming Mg-like. The data are archived according to the Atomic Data and Analysis Structure (ADAS) data class adf48, which spans a temperature range of z\textsuperscript{2}(10\textsuperscript{1}-10\textsuperscript{7}) K, where z is the initial ion charge. Fits to total rate coefficients have been determined, for both the ground and metastable levels, and those for the ground are presented here. Comparison is made both with previous RR rate coefficients and with (background) R-matrix photoionization cross sections. This RR database complements a dielectronic recombination (DR) database already produced, and both are being used to produce updated ionization balances for both (electron) collisionally ionized and photoionized plasmas.}
 }
 
+@article{barnes_understanding_2019,
+  title = {Understanding {{Heating}} in {{Active Region Cores}} through {{Machine Learning}}. {{I}}. {{Numerical Modeling}} and {{Predicted Observables}}},
+  author = {Barnes, W. T. and Bradshaw, S. J. and Viall, N. M.},
+  year = {2019},
+  month = jul,
+  journal = {ApJ},
+  volume = {880},
+  number = {1},
+  pages = {56},
+  doi = {10.3847/1538-4357/ab290c},
+  abstract = {To adequately constrain the frequency of energy deposition in active region cores in the solar corona, systematic comparisons between detailed models and observational data are needed. In this paper, we describe a pipeline for forward modeling active region emission using magnetic field extrapolations and field-aligned hydrodynamic models. We use this pipeline to predict time-dependent emission from active region NOAA 1158 for low-, intermediate-, and high-frequency nanoflares. In each pixel of our predicted multi-wavelength, time-dependent images, we compute two commonly used diagnostics: the emission measure slope and the time lag. We find that signatures of the heating frequency persist in both of these diagnostics. In particular, our results show that the distribution of emission measure slopes narrows and the mean decreases with decreasing heating frequency and that the range of emission measure slopes is consistent with past observational and modeling work. Furthermore, we find that the time lag becomes increasingly spatially coherent with decreasing heating frequency while the distribution of time lags across the whole active region becomes more broad with increasing heating frequency. In a follow-up paper, we train a random forest classifier on these predicted diagnostics and use this model to classify real observations of NOAA 1158 in terms of the underlying heating frequency.},
+  langid = {english}
+}
+
+@article{bradshaw_numerical_2009,
+  title = {A Numerical Tool for the Calculation of Non-Equilibrium Ionisation States in the Solar Corona and Other Astrophysical Plasma Environments},
+  author = {Bradshaw, S. J.},
+  year = {2009},
+  month = jul,
+  journal = {A\&A},
+  volume = {502},
+  pages = {409--418},
+  issn = {0004-6361},
+  doi = {10.1051/0004-6361/200810735},
+  abstract = {Context: The effects of non-equilibrium processes on the ionisation  state of strongly emitting elements in the solar corona can be extremely difficult to assess and yet they are critically important. For example, there is much interest in dynamic heating events localised in the solar corona because they are believed to be responsible for its high temperature and yet recent work has shown that the hottest ({$\geq$}107 K) emission predicted to be associated with these events can be observationally elusive due to the difficulty of creating the highly ionised states from which the expected emission arises. This leads to the possibility of observing instruments missing such heating events entirely. Aims: The equations describing the evolution of the ionisaton state are a very stiff system of coupled, partial differential equations whose solution can be numerically challenging and time-consuming. Without access to specialised codes and significant computational resources it is extremely difficult to avoid the assumption of an equilibrium ionisation state even when it clearly cannot be justified. The aim of the current work is to develop a computational tool to allow straightforward calculation of the time-dependent ionisation state for a wide variety of physical circumstances. Methods: A numerical model comprising the system of time-dependent ionisation equations for a particular element and tabulated values of plasma temperature as a function of time is developed. The tabulated values can be the solutions of an analytical model, the output from a numerical code or a set of observational measurements. An efficient numerical method to solve the ionisation equations is implemented. Results: A suite of tests is designed and run to demonstrate that the code provides reliable and accurate solutions for a number of scenarios including equilibration of the ion population and rapid heating followed by thermal conductive cooling. It is found that the solver can evolve the ionisation state to recover exactly the equilibrium state found by an independent, steady-state solver for all temperatures, resolve the extremely small ionisation/recombination timescales associated with rapid temperature changes at high densities, and provide stable and accurate solutions for both dominant and minor ion population fractions. Rapid heating and cooling of low to moderate density plasma is characterised by significant non-equilibrium ionisation conditions. The effective ionisation temperatures are significantly lower than the electron temperature and the values found are in close agreement with the previous work of others. At the very highest densities included in the present study an assumption of equilibrium ionisation is found to be robust. Conclusions: The computational tool presented here provides a straightforward and reliable way to calculate ionisation states for a wide variety of physical circumstances. The numerical code gives results that are accurate and consistent with previous studies, has relatively undemanding computational requirements and is freely available from the author.},
+  keywords = {ATOMIC PROCESSES,Methods: Numerical,Sun: corona,SUN: UV RADIATION}
+}
+
 @article{burgess_analysis_1992,
   title = {On the {{Analysis}} of {{Collision Strengths}} and {{Rate Coefficients}}},
   author = {Burgess, A. and Tully, J. A.},

--- a/examples/nei_populations.py
+++ b/examples/nei_populations.py
@@ -1,0 +1,169 @@
+"""
+Non-equilibrium Ionization
+===========================
+
+In this example, we'll show how to compute the ionization
+fractions of iron in the case where the the timescale of the
+temperature change is shorter than the ionization timescale.
+This is often referred to as *non-equilibrium ionization*.
+"""
+import numpy as np
+from scipy.interpolate import interp1d
+import matplotlib.pyplot as plt
+import astropy.units as u
+from astropy.visualization import quantity_support
+quantity_support()
+
+from fiasco import Element
+
+###############################################################
+# The time evolution of an ion fraction :math:`f_k` for some
+# ion :math:`k` for some element is given by,
+#
+# .. math::
+#
+#     \frac{d}{dt}f_k = n_e(\alpha_{k-1}^I f_{k-1} + \alpha_{k+1}^R f_{k+1} - \alpha_{k}^I f_k - \alpha_k^R f_k),
+#
+# where :math:`n_e` is the electron density, :math:`\alpha^I` is
+# the ionization rate, and :math:`\alpha^R` is the recombination.
+# Both the ionization and recombination rates are a function of
+# electron temperature :math:`T_e`.
+#
+# Consider a very simple temperature evolution model in which the
+# electron temperature rises from :math:`10^4` K to
+# :math:`1.5\times10^7` K over 15 s and then decreases back
+# to :math:`10^4` K.
+t = np.arange(0, 30, 0.01) * u.s
+Te_min = 1e4 * u.K
+Te_max = 15e6 * u.K
+t_mid = 15 * u.s
+Te = Te_min + (Te_max - Te_min) / t_mid * t
+Te[t>t_mid] = Te_max - (Te_max - Te_min) / t_mid * (t[t>t_mid] - t_mid)
+
+###############################################################
+# Similarly, we'll model the density as increasing from
+# :math:`10^8\,\mathrm{cm}^{-3}` to :math:`1.5^10\,\mathrm{cm}^{-3}`
+# and then back down to :math:`10^8\,\mathrm{cm}^{-3}`.
+ne_min = 1e8 * u.cm**(-3)
+ne_max = 1.5e10 * u.cm**(-3)
+ne = ne_min + (ne_max - ne_min) / t_mid * t
+ne[t>t_mid] = ne_max - (ne_max - ne_min) / t_mid * (t[t>t_mid] - t_mid)
+
+
+###############################################################
+# We can plot the temperature and density as a function of time.
+plt.figure(figsize=(12,5))
+plt.subplot(121)
+plt.plot(t,Te.to('MK'))
+plt.subplot(122)
+plt.plot(t,ne)
+plt.show()
+
+###############################################################
+# In the case where the ionization fraction is in equilibrium,
+# the left hand side of the above equation is zero.
+# As shown in previous examples, we can get the ion population
+# fractions of any element in the CHIANTI database over some
+# temperature array with `~fiasco.Element.equilibrium_ionization`.
+# First, let's model the ionization fractions of Fe for the above
+# temperature model, assuming ionization equilibrium.
+temperature_array = np.logspace(4, 8, 1000) * u.K
+fe = Element('iron', temperature_array)
+func_interp = interp1d(fe.temperature.to_value('K'), fe.equilibrium_ionization.value,
+                       axis=0, kind='cubic', fill_value='extrapolate')
+fe_ieq = u.Quantity(func_interp(Te.to_value('K')))
+
+###############################################################
+# We can plot the population fractions for Fe IX through Fe XXVII as a function of time.
+plt.figure(figsize=(12, 4))
+for i in range(8,27):
+    plt.plot(t, fe_ieq[:, i], label=fe[i].roman_name)
+plt.xlim(t[[0,-1]].value)
+plt.legend(ncol=4, frameon=False)
+plt.show()
+
+###############################################################
+# Now, let's compute the population fractions in the case where
+# the population fractions are out of equilibrium.
+# We solve the above equation using the implicit method outlined
+# in Appendix A of :cite:t:`barnes_understanding_2019`,
+#
+# .. math::
+#
+#     \mathbf{F}_{l+1} = \left(\mathbb{I} - \frac{\delta}{2}\mathbf{A}_{l+1}\right)^{-1}\left(\mathbb{I} + \frac{\delta}{2}\mathbf{A}_l\right)\mathbf{F}_l
+#
+# where :math:`\mathbf{F}_l` is the vector of population fractions
+# of all states at time :math:`t_l`, :math:`\mathbf{A}_l` is the
+# matrix of ionization and recombination rates with dimension
+# :math:`Z+1\times Z+1` at time :math:`t_l`,  and :math:`\delta`
+# is the time step.
+#
+# First, we can set our inital state to the equilibrium populations.
+fe_nei = np.zeros(t.shape + (fe.atomic_number + 1,))
+fe_nei[0, :] = fe_ieq[0,:]
+
+###############################################################
+# Then, interpolate the rate matrix to our modeled temperatures
+func_interp = interp1d(fe.temperature.to_value('K'), fe._rate_matrix.value,
+                       axis=0, kind='cubic', fill_value='extrapolate')
+fe_rate_matrix = func_interp(Te.to_value('K')) * fe._rate_matrix.unit
+
+###############################################################
+# Finally, we can iteratively compute the non-equilibrium ion
+# fractions using the above equation.
+identity = u.Quantity(np.eye(fe.atomic_number + 1))
+for i in range(1, t.shape[0]):
+    dt = t[i] - t[i-1]
+    term1 = identity - ne[i] * dt/2. * fe_rate_matrix[i, ...]
+    term2 = identity + ne[i-1] * dt/2. * fe_rate_matrix[i-1, ...]
+    fe_nei[i, :] = np.linalg.inv(term1) @ term2 @ fe_nei[i-1, :]
+    fe_nei[i, :] = np.fabs(fe_nei[i, :])
+    fe_nei[i, :] /= fe_nei[i, :].sum()
+
+fe_nei = u.Quantity(fe_nei)
+
+###############################################################
+# And overplot the non-equilibrium populations on top of the
+# equilibrium populations
+plt.figure(figsize=(12,4))
+for i in range(8,27):
+    plt.plot(t, fe_nei[:, i], ls='-', label=fe[i].roman_name,)
+plt.xlim(t[[0,-1]].value)
+plt.legend(ncol=4, frameon=False)
+plt.show()
+
+###############################################################
+# We can compare the two equilibrium and non equilbrium cases
+# directly by overplotting the Fe XVI population fractions for
+# the two cases.
+plt.figure(figsize=(12,4))
+plt.plot(t, fe_ieq[:, 15], label='IEQ')
+plt.plot(t, fe_nei[:, 15], label='NEI',)
+plt.xlim(t[[0,-1]].value)
+plt.legend(frameon=False)
+plt.show()
+
+###############################################################
+# Note that the equilibrium populations exactly track the
+# temperature evolution while the peak of the non-equilibrium
+# Fe XVI population lags the equilibrium case and is not symmetric.
+#
+# Finally let's plot the effective temperature as described in
+# :cite:t:`bradshaw_numerical_2009`. Qualitatively, this is the
+# temperature that one would infer if they observed the
+# non-equilibrium populations and assumed the populations
+# were in equilibrium.
+Te_eff =  fe.temperature[[(np.fabs(fe.equilibrium_ionization - fe_nei[i,:])).sum(axis=1).argmin()
+                          for i in range(fe_nei.shape[0])]]
+plt.plot(t, Te.to('MK'), label=r'$T$')
+plt.plot(t, Te_eff.to('MK'), label='$T_{\mathrm{eff}}$')
+plt.xlim(t[[0,-1]].value)
+plt.legend()
+plt.show()
+
+###############################################################
+# Note that the effective temperature is consistently less than
+# the actual temperature, emphasizing the point that
+# non-equilibrium ionization makes it difficult to detect very
+# hot plasma when the temperature changes rapidly and/or the
+# density is low.


### PR DESCRIPTION
Fixes #163 

This adds an example gallery entry for computing the time-dependent ion population fractions.