### PR TITLE
Refactor parsing of ion name inputs

### DIFF
--- a/examples/aia_response.py
+++ b/examples/aia_response.py
@@ -86,7 +86,7 @@ plt.xscale('log')
 plt.yscale('log')
 plt.ylim(1e-29, 1e-26)
 plt.xlim(1e5, 3e7)
-plt.title(f'{ch.channel.to_string(format="latex")} Response for {fe18.roman_name}')
+plt.title(f'{ch.channel.to_string(format="latex")} Response for {fe18.ion_name_roman}')
 plt.show()
 
 ############################################################

--- a/examples/nei_populations.py
+++ b/examples/nei_populations.py
@@ -78,7 +78,7 @@ carbon_ieq = u.Quantity(func_interp(Te.to_value('K')))
 # We can plot the population fractions as a function of time.
 plt.figure(figsize=(12, 4))
 for ion in carbon:
-    plt.plot(t, carbon_ieq[:, ion.charge_state], label=ion.roman_name)
+    plt.plot(t, carbon_ieq[:, ion.charge_state], label=ion.ion_name_roman)
 plt.xlim(t[[0,-1]].value)
 plt.legend(ncol=4, frameon=False)
 plt.show()
@@ -127,7 +127,7 @@ carbon_nei = u.Quantity(carbon_nei)
 # And plot the non-equilibrium populations as a function of time
 plt.figure(figsize=(12,4))
 for ion in carbon:
-    plt.plot(t, carbon_nei[:, ion.charge_state], ls='-', label=ion.roman_name,)
+    plt.plot(t, carbon_nei[:, ion.charge_state], ls='-', label=ion.ion_name_roman,)
 plt.xlim(t[[0,-1]].value)
 plt.legend(ncol=4, frameon=False)
 plt.show()

--- a/examples/plot_ioneq.py
+++ b/examples/plot_ioneq.py
@@ -31,7 +31,7 @@ for ion in el:
     ioneq = el.equilibrium_ionization[:, ion.charge_state]
     imax = np.argmax(ioneq)
     plt.plot(el.temperature, ioneq)
-    plt.text(el.temperature[imax], ioneq[imax], ion.roman_numeral,
+    plt.text(el.temperature[imax], ioneq[imax], ion.ionization_stage_roman,
              horizontalalignment='center')
 plt.xscale('log')
 plt.title(f'{el.atomic_symbol} Equilibrium Ionization')
@@ -47,7 +47,7 @@ plt.show()
 # for temperatures outside of the tabulated temperature data given in CHIANTI.
 plt.plot(el.temperature, el[3].ioneq)
 plt.xscale('log')
-plt.title(f'{el[3].roman_name} Equilibrium Ionization')
+plt.title(f'{el[3].ion_name_roman} Equilibrium Ionization')
 plt.show()
 
 ################################################
@@ -60,5 +60,5 @@ plt.plot(el.temperature, el[3].ioneq, label='interpolated')
 plt.xlim(4e4, 3e5)
 plt.xscale('log')
 plt.legend()
-plt.title(f'{el[3].roman_name} Equilibrium Ionization')
+plt.title(f'{el[3].ion_name_roman} Equilibrium Ionization')
 plt.show()

--- a/fiasco/collections.py
+++ b/fiasco/collections.py
@@ -5,9 +5,9 @@ import numpy as np
 import astropy.units as u
 from astropy.convolution import convolve, Model1DKernel
 from astropy.modeling.models import Gaussian1D
-import plasmapy
 
 import fiasco
+from fiasco.util import parse_ion_name
 from fiasco.util.exceptions import MissingDatasetException
 
 __all__ = ['IonCollection']
@@ -47,20 +47,20 @@ class IonCollection(object):
             return ions
 
     def __contains__(self, value):
-        if type(value) is str:
-            el, ion = value.split()
-            if '+' in ion:
-                ion = int(ion.strip('+')) + 1
-            value = f'{plasmapy.particles.atomic_symbol(el)} {ion}'
+        if isinstance(value, (str, tuple)):
+            pair = parse_ion_name(value)
         elif isinstance(value, fiasco.Ion):
-            value = value.ion_name
-        return value in [i.ion_name for i in self._ion_list]
+            pair = value._base_rep
+        return pair in [i._base_rep for i in self._ion_list]
 
     def __add__(self, value):
         return IonCollection(self, value)
 
     def __radd__(self, value):
         return IonCollection(value, self)
+
+    def __len__(self):
+        return len(self._ion_list)
 
     @property
     def temperature(self,):

--- a/fiasco/tests/test_base.py
+++ b/fiasco/tests/test_base.py
@@ -14,6 +14,8 @@ from fiasco.util.exceptions import MissingIonError
     "iron XXI",
     "Fe xxi",
     "Fe 20+",
+    (26, 21),
+    ("Fe", "XXI"),
 ])
 def test_create_ion_input_formats(hdf5_dbase_root, ion_name):
     ion = fiasco.base.IonBase(ion_name, hdf5_dbase_root=hdf5_dbase_root)
@@ -23,8 +25,8 @@ def test_create_ion_input_formats(hdf5_dbase_root, ion_name):
     assert ion.ionization_stage == 21
     assert ion.charge_state == 20
     assert ion._ion_name == 'fe_21'
-    assert ion.roman_name == 'Fe XXI'
-    assert ion.roman_numeral == 'XXI'
+    assert ion.ion_name_roman == 'Fe XXI'
+    assert ion.ionization_stage_roman == 'XXI'
 
 
 def test_create_invalid_ion_raises_missing_ion_error(hdf5_dbase_root):

--- a/fiasco/util/tests/test_util.py
+++ b/fiasco/util/tests/test_util.py
@@ -1,0 +1,24 @@
+"""
+Tests for util functions
+"""
+import pytest
+
+from fiasco.util import parse_ion_name
+
+@pytest.mark.parametrize('ion_name', [
+    "fe 21",
+    "Fe 21",
+    "Iron 21",
+    "iron XXI",
+    "Fe xxi",
+    "Fe 20+",
+    "fe_21",
+    "26 21",
+    (26, 21),
+    ("26", "21"),
+    ("iron", "XXI"),
+])
+def test_parse_ion_name(ion_name):
+    element, ion = parse_ion_name(ion_name)
+    assert element == 26
+    assert ion == 21

--- a/fiasco/util/util.py
+++ b/fiasco/util/util.py
@@ -16,17 +16,18 @@ __all__ = ['setup_paths', 'get_masterlist', 'parse_ion_name']
 
 def parse_ion_name(ion_name):
     """
-    Parse the atomic number and ionization stage from string representation of ion
+    Parse the atomic number and ionization stage from representation of ion.
 
     This function can take a number of formats for the ion name. As an example, all
     of the following representations of Fe 18, that is, an iron ion
     with 17 electrons removed and a total charge of +17, will return (26,18):
 
-    1. 'Fe 18', 'fe 18' (atomic symbol and number)
-    2. 'Fe 17+' (atomic symbol and charge)
-    3. 'Iron 18', 'iron 18' (element name and number)
-    4. 'Fe XVIII', 'fe xviii' (atomic symbol and roman numeral designation)
-    5. '26 18' (atomic number and number)
+    1. `'Fe 18'`, `'fe 18'` (atomic symbol and ionization stage)
+    2. `'Fe 17+'` (atomic symbol and charge state)
+    3. `'Iron 18'`, `'iron 18'` (element name and ionization stage)
+    4. `'Fe XVIII'`, `'fe xviii'` (atomic symbol and ionization stage in spectroscopic notation)
+    5. `'26 18'` (atomic number and ionization stage)
+    6. `(26, 18)` (tuple of any combination of the above)
     """
     if isinstance(ion_name, tuple):
         element, ion = ion_name


### PR DESCRIPTION
This is a refactor of how ions are specified when constructing an `Ion` object.

In particular, this adds a function `parse_ion_name` that handles all parsing of the inputs to the `Base` constructor. This function always returns a tuple of integers `(atomic number, ionization_state)`. All of the properties on `Ion` are then built using this format. As a result, the inputs to `Ion` for specifying an ion are now more flexible, e.g. you can specify Fe XVIII using a tuple `(26, 18)`.

Additionally, `Ion.roman_name` is now `Ion.ion_name_roman` and `Ion.roman_numeral` is now `Ion.ionization_state_roman`.

Using `len` on an `IonCollection` also now returns the number of ions in the collection.