### PR TITLE
Add `codespell` to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,8 @@ repos:
         exclude: ".*(.fits|.fts|.fit|.txt|tca.*)$"
       - id: mixed-line-ending
         exclude: ".*(.fits|.fts|.fit|.txt|tca.*)$"
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.2
+    hooks:
+      - id: codespell

--- a/examples/nei_populations.py
+++ b/examples/nei_populations.py
@@ -99,7 +99,7 @@ plt.show()
 # :math:`Z+1\times Z+1` at time :math:`t_l`,  and :math:`\delta`
 # is the time step.
 #
-# First, we can set our inital state to the equilibrium populations.
+# First, we can set our initial state to the equilibrium populations.
 carbon_nei = np.zeros(t.shape + (carbon.atomic_number + 1,))
 carbon_nei[0, :] = carbon_ieq[0,:]
 

--- a/fiasco/ion.py
+++ b/fiasco/ion.py
@@ -568,7 +568,7 @@ Using Datasets:
         """
         Construct the spectrum using a given filter over a specified wavelength range.
 
-        All arguments are passed direclty to `fiasco.IonCollection.spectrum`.
+        All arguments are passed directly to `fiasco.IonCollection.spectrum`.
 
         See Also
         --------

--- a/fiasco/util/tools.py
+++ b/fiasco/util/tools.py
@@ -25,7 +25,7 @@ def vectorize_where(x_1, x_2):
 
 def vectorize_where_sum(x_1, x_2, y, axis=None):
     """
-    Find all occurences of one array in another and sum over a third
+    Find all occurrences of one array in another and sum over a third
 
     Parameters
     ----------
@@ -137,7 +137,7 @@ def burgess_tully_descale(x, y, energy_ratio, c, scaling_type):
         Ratio between the thermal energy and that of each transition with shape ``(n,m)``,
         where ``m`` is the dimension of the temperature array.
     c : `array-like`
-        Scaling constant for each transiton with shape ``(n,)``
+        Scaling constant for each transition with shape ``(n,)``
     scaling_type : `array-like`
         The type of descaling to apply for each transition with shape ``(n,)``. Must be between
         1 and 6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,3 @@ build-backend = 'setuptools.build_meta'
       directory = "trivial"
       name = "Trivial/Internal Changes"
       showcontent = true
-
-[tool.codespell]
-skip="*.dat,*.fits,*.hdr,.idea,*.xml,.git,*extern,fitshdr.htest_groups.py"
-ignore-words-list = "te,ti"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,3 +46,7 @@ build-backend = 'setuptools.build_meta'
       directory = "trivial"
       name = "Trivial/Internal Changes"
       showcontent = true
+
+[tool.codespell]
+skip="*.dat,*.fits,*.hdr,.idea,*.xml,.git,*extern,fitshdr.htest_groups.py"
+ignore-words-list = "te,ti"

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,3 +80,8 @@ exclude_lines =
   pragma: py{ignore_python_version}
   # Don't complain about IPython completion helper
   def _ipython_key_completions_
+
+[codespell]
+skip = *.png,*cache*,*egg*,.git,.idea,.tox,_build
+ignore-words-list =
+    te

--- a/tox.ini
+++ b/tox.ini
@@ -17,14 +17,14 @@ requires =
 # should be empty.
 pypi_filter_requirements = https://raw.githubusercontent.com/sunpy/package-template/master/sunpy_version_pins.txt
 
-# Pass through the following environemnt variables which may be needed for the CI
+# Pass through the following environment variables which may be needed for the CI
 passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS
 
 # Run the tests in a temporary directory to make sure that we don't import
 # the package from the source tree
 changedir = .tmp/{envname}
 
-# tox environments are constructued with so-called 'factors' (or terms)
+# tox environments are constructed with so-called 'factors' (or terms)
 # separated by hyphens, e.g. test-devdeps-cov. Lines below starting with factor:
 # will only take effect if that factor is included in the environment name. To
 # see a list of example environments that can be run, along with a description,


### PR DESCRIPTION
This pull request adds [codespell](https://github.com/codespell-project/codespell) to the pre-commit configuration.  

Instead of searching for words that don't show up in a dictionary, codespell looks for words that match a dictionary of common misspellings.  Consequently, codespell leads to many fewer false positives than more traditional spellcheckers applied to code, but it will not catch all misspellings.  In this repo, the only false positive was `te`.

I added a codespell configuration section to `setup.cfg`, including which files and words to ignore.

I originally attempted to add the configuration to `pyproject.toml`, but when running `pre-commit run --all-files`, it was not picking up the configuration there, even though it did so when running codespell regularly.