### PR TITLE
Include Python 3.11 in test suite

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,6 +36,10 @@ jobs:
           python-version: '3.10'
           cache_cmd: -- --dbase-download-dir ~/.chianti
           toxenv: py310
+        - os: ubuntu-latest
+          python-version: '3.11'
+          cache_cmd: -- --dbase-download-dir ~/.chianti
+          toxenv: py311
         # Docs
         - os: ubuntu-latest
           python-version: 3.9

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -42,11 +42,11 @@ jobs:
           toxenv: py311
         # Docs
         - os: ubuntu-latest
-          python-version: 3.9
+          python-version: '3.11'
           toxenv: build_docs
         # Code style checks
         - os: ubuntu-latest
-          python-version: 3.9
+          python-version: '3.11'
           toxenv: codestyle
 
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: 3.8
           toxenv: py38
           cache_cmd: -- --dbase-download-dir ~/.chianti
-        - os: windows-latest
+        - os: ubuntu-latest
           python-version: 3.9
           toxenv: py39
           cache_cmd: -- --dbase-download-dir ~/.chianti

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,14 +14,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        # Test the oldest and newest configuration on Mac and Windows
+        # Test the oldest and newest configuration on Mac
         - os: macos-latest
           python-version: 3.8
           toxenv: py38
           cache_cmd: -- --dbase-download-dir ~/.chianti
         - os: macos-latest
-          python-version: 3.8
-          toxenv: py38
+          python-version: '3.11'
+          toxenv: py310
           cache_cmd: -- --dbase-download-dir ~/.chianti
         # Test all configurations on Linux
         - os: ubuntu-latest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: 3.8
           toxenv: py38
           cache_cmd: -- --dbase-download-dir ~/.chianti
-        - os: ubuntu-latest
+        - os: windows-latest
           python-version: 3.9
           toxenv: py39
           cache_cmd: -- --dbase-download-dir ~/.chianti


### PR DESCRIPTION
This PR makes two changes to `tox.ini` in preparation for a v0.1.0 release:
 - Add a test for Python 3.11 to the test suite
 - ~~Change the Python 3.9 test to `windows-latest`~~

Because PlasmaPy depends on Numba (at least for now), and fiasco depends on PlasmaPy, it'll be necessary to wait until Numba works on Python 3.11.  