### PR TITLE
Enable tests with Windows and begin `os.path` → `pathlib` transition

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,14 +14,23 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        # Test the oldest and newest configuration on Mac and Windows
+        # Test the oldest and newest configuration on Mac
         - os: macos-latest
           python-version: 3.8
           toxenv: py38
           cache_cmd: -- --dbase-download-dir ~/.chianti
         - os: macos-latest
+          python-version: '3.10'
+          toxenv: py310
+          cache_cmd: -- --dbase-download-dir ~/.chianti
+        # Test the oldest and newest configuration on Windows
+        - os: windows-latest
           python-version: 3.8
           toxenv: py38
+          cache_cmd: -- --dbase-download-dir ~/.chianti
+        - os: windows-latest
+          python-version: '3.10'
+          toxenv: py310
           cache_cmd: -- --dbase-download-dir ~/.chianti
         # Test all configurations on Linux
         - os: ubuntu-latest

--- a/fiasco/util/setup_db.py
+++ b/fiasco/util/setup_db.py
@@ -76,9 +76,8 @@ def download_dbase(ascii_dbase_url, ascii_dbase_root):
     """
     Download the CHIANTI database in ASCII format
     """
-    tar_tmp_dir = os.path.join(FIASCO_HOME, 'tmp')
-    if not os.path.exists(tar_tmp_dir):
-        os.makedirs(tar_tmp_dir)
+    tar_tmp_dir = FIASCO_HOME / 'tmp'
+    tar_tmp_dir.mkdir(exist_ok=True)
     with set_temp_cache(path=tar_tmp_dir, delete=True):
         tmp_tar = download_file(ascii_dbase_url, cache=True, show_progress=True)
         with tarfile.open(tmp_tar) as tar:

--- a/fiasco/util/setup_db.py
+++ b/fiasco/util/setup_db.py
@@ -10,13 +10,14 @@ import tarfile
 from astropy.config import set_temp_cache
 from astropy.utils.console import ProgressBar
 from astropy.utils.data import download_file
+from pathlib import Path
 
 import fiasco.io
 
 from fiasco.util.exceptions import MissingASCIIFileError
 from fiasco.util.util import get_masterlist, query_yes_no
 
-FIASCO_HOME = os.path.join(os.environ['HOME'], '.fiasco')
+FIASCO_HOME = Path.home() / '.fiasco'
 CHIANTI_URL = 'http://download.chiantidatabase.org/CHIANTI_v{version}_database.tar.gz'
 LATEST_VERSION = '8.0.7'
 

--- a/fiasco/util/util.py
+++ b/fiasco/util/util.py
@@ -6,9 +6,10 @@ import os
 import plasmapy.particles
 import sys
 
+from pathlib import Path
 from plasmapy.utils import roman
 
-FIASCO_HOME = os.path.join(os.environ['HOME'], '.fiasco')
+FIASCO_HOME = Path.home() / '.fiasco'
 
 __all__ = ['setup_paths', 'get_masterlist', 'parse_ion_name']
 


### PR DESCRIPTION
This is my second attempt to fix an problem with running tests on Windows.  I'm attempting this in a different PR because I kept getting a temporary path not found error in #182 that I had trouble tracking down.  I had tests passing on my workstation, but an error on GitHub.  I'm going to try to track down the exact changes that I made that broke this.

This supersedes #182. Probably.

Closes https://github.com/wtbarnes/fiasco/issues/179. I previously tried Windows tests on https://github.com/wtbarnes/fiasco/pull/176.