### PR TITLE
Parallelise eigen{vec,val} calculations

### DIFF
--- a/fiasco/ions.py
+++ b/fiasco/ions.py
@@ -458,12 +458,17 @@ Using Datasets:
                 c_matrix[:, upper_level_p-1, lower_level_p-1] += d_p * ex_rate_p
 
             # Invert matrix
-            os.environ['OMP_NUM_THREADS'] = "1"
-            with mp.Pool() as p:
-                val_vecs = p.map(np.linalg.eig, c_matrix.value)
+            if c_matrix.shape[0] > 12:
+                # Overheads of multiprocessing mean this is only worth
+                # parallelising for many matrices to solve
+                os.environ['OMP_NUM_THREADS'] = "1"
+                with mp.Pool() as p:
+                    val_vecs = p.map(np.linalg.eig, c_matrix.value)
 
-            val = np.stack([v[0] for v in val_vecs])
-            vec = np.stack([v[1] for v in val_vecs])
+                val = np.stack([v[0] for v in val_vecs])
+                vec = np.stack([v[1] for v in val_vecs])
+            else:
+                val, vec = np.linalg.eig(c_matrix.value)
 
             # Eigenvectors with eigenvalues closest to zero are the solutions to the homogeneous
             # system of linear equations


### PR DESCRIPTION
xref https://github.com/wtbarnes/fiasco/issues/26. I realised that it should be possible to parallelise the computation on many different matrices. I'm not sure this is *the* right approach, as in my experience doing a naïve `multiprocessing` implementation isn't rarely the best way of doing parallel stuff, but opening for discussion.

With the following code:
```python
import astropy.units as u
import numpy as np

from fiasco import Ion

if __name__ == '__main__':
    Te = np.geomspace(0.1, 100, 41) * u.MK
    ne = 1e8 * u.cm**-3

    ion = Ion('Fe XII', Te)
    print(ion)

    contribution_func = ion.contribution_function(ne)
```

parallelising the eigen{vector, value} calculation speeds it up from ~26secs to 14secs in total for me.

```
26.122 <module>  cont_func.py:1
├─ 23.632 func_wrapper  fiasco/util/decorators.py:22
│  └─ 23.631 wrapper  astropy/units/decorators.py:226
│        [8 frames hidden]  astropy, <built-in>
│           23.628 Ion.contribution_function  fiasco/ions.py:473
│           └─ 23.401 func_wrapper  fiasco/util/decorators.py:22
│              └─ 23.392 wrapper  astropy/units/decorators.py:226
│                    [2 frames hidden]  astropy
│                       23.381 Ion.level_populations  fiasco/ions.py:376
│                       ├─ 19.845 eig  <__array_function__ internals>:177
```
to 
```
14.312 <module>  cont_func.py:1
├─ 11.843 func_wrapper  fiasco/util/decorators.py:22
│  └─ 11.842 wrapper  astropy/units/decorators.py:226
│        [9 frames hidden]  astropy, <built-in>
│           11.839 Ion.contribution_function  fiasco/ions.py:482
│           ├─ 11.604 func_wrapper  fiasco/util/decorators.py:22
│           │  └─ 11.593 wrapper  astropy/units/decorators.py:226
│           │        [2 frames hidden]  astropy
│           │           11.580 Ion.level_populations  fiasco/ions.py:378
│           │           ├─ 7.968 Pool.map  multiprocessing/pool.py:362
```