### PR TITLE
Fix version checking

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,3 +12,5 @@ def pytest_addoption(parser):
     parser.addoption('--idl-executable', action='store', default=None)
     parser.addoption('--idl-codebase-root', action='store', default=None)
     parser.addoption('--include-all-files', action='store', default=False)
+    parser.addoption('--skip-version-check', action='store_true', default=False,
+                     help='Do not check CHIANTI version')

--- a/fiasco/conftest.py
+++ b/fiasco/conftest.py
@@ -115,12 +115,15 @@ def hdf5_dbase_root(ascii_dbase_tree, tmpdir_factory, request):
             test_files = TEST_FILES
     # Optionally use a different URL for the database (e.g. for testing different versions)
     ascii_dbase_url = request.config.getoption('--ascii-dbase-url')
+    # Optionally disable version checking. This is useful when testing newer/older versions
+    # of CHIANTI
+    check_chianti_version = not request.config.getoption('--skip-version-check')
     # Finally, run the database setup
     check_database(path,
                    ascii_dbase_root=ascii_dbase_tree,
                    ask_before=False,
                    ascii_dbase_url=ascii_dbase_url,
-                   check_chianti_version=False,
+                   check_chianti_version=check_chianti_version,
                    files=test_files)
     return path
 

--- a/fiasco/io/factory.py
+++ b/fiasco/io/factory.py
@@ -40,7 +40,7 @@ class ParserFactory(type):
         elif filetype_name in subclass_dict:
             return subclass_dict[filetype_name](*args, **kwargs)
         else:
-            log.warning(f'Unrecognized filename and extension {args[0]}', stacklevel=2)
+            log.debug(f'Unrecognized filename and extension {args[0]}', stacklevel=2)
             return type.__call__(cls, *args, **kwargs)
 
 

--- a/fiasco/ions.py
+++ b/fiasco/ions.py
@@ -89,7 +89,7 @@ Charge: +{self.charge_state}
 Number of Levels: {n_levels}
 Number of Transitions: {n_transitions}
 
-Temperature range: [{self.temperature[0].to(u.MK):.3f}, {self.temperature[-1].to(u.MK)}:.3f]
+Temperature range: [{self.temperature[0].to(u.MK):.3f}, {self.temperature[-1].to(u.MK):.3f}]
 
 HDF5 Database: {self.hdf5_dbase_root}
 Using Datasets:

--- a/fiasco/util/setup_db.py
+++ b/fiasco/util/setup_db.py
@@ -92,7 +92,7 @@ def check_database(hdf5_dbase_root, **kwargs):
 
 
 def check_database_version(hdf5_dbase_root):
-    dl = DataIndexer.create_indexer(hdf5_dbase_root, '/')
+    dl = DataIndexer.create_indexer(hdf5_dbase_root, '/h/h_1/elvlc')
     if dl.version not in SUPPORTED_VERSIONS:
         raise UnsupportedVersionError(
             f'CHIANTI {dl.version} is not in the list of supported versions {SUPPORTED_VERSIONS}.')


### PR DESCRIPTION
Fixes #209 

There is a bug in checking the compatible CHIANTI versions. This fixes it by checking for the version in the right place. 

This also includes a few fixes that make the building of the HDF5 file much more quiet by default.