### PR TITLE
Add parser for DEM files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
     - id: absolufy-imports
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     - id: isort
       name: isort

--- a/fiasco/conftest.py
+++ b/fiasco/conftest.py
@@ -26,6 +26,7 @@ TEST_FILES = {
     'hseq_2photon.dat':                     '48656984fbcbe38f883ff9a4460c790a',
     'heseq_2photon.dat':                    '9e42ac8c37d67ba3109aaa56aab9e736',
     'verner_short.txt':                     'f05296ffc9c5306846ac9caf136fad26',
+    'flare.dem':                            '1eb949e8c7fd2cb3e9e6903e85d86217',
     'h_1.elvlc':                            'd31620aaf26a14486e635d14bcf7a6c1',
     'h_1.wgfa':                             'ed2a561ecdba5ee4b05ea56c297724ba',
     'h_1.scups':                            'de180c9e1b4f50a503efad8c83e714ab',

--- a/fiasco/io/sources/tests/test_sources.py
+++ b/fiasco/io/sources/tests/test_sources.py
@@ -47,13 +47,14 @@ def test_ion_sources(ascii_dbase_root, filename,):
     'itoh.dat',
     'klgfb.dat',
     'verner_short.txt',
+    'flare.dem',
 ])
 def test_non_ion_sources(ascii_dbase_root, filename):
     parser = fiasco.io.Parser(filename, ascii_dbase_root=ascii_dbase_root)
     table = parser.parse()
     assert isinstance(table, QTable)
     assert all([k in table.meta for k in ('footer', 'filename', 'chianti_version', 'descriptions')])
-    assert table.colnames == parser.headings
+    assert all([h in table.colnames for h in parser.headings])
     for h, unit in zip(parser.headings, parser.units):
         assert table[h].unit == unit
     assert table.meta['filename'] == filename

--- a/fiasco/tests/test_element.py
+++ b/fiasco/tests/test_element.py
@@ -78,7 +78,7 @@ def test_equilibrium_ionization(hdf5_dbase_root):
     carbon = fiasco.Element('C', temperature, hdf5_dbase_root=hdf5_dbase_root)
     ioneq = carbon.equilibrium_ionization
     assert ioneq.shape == carbon.temperature.shape + (carbon.atomic_number + 1,)
-    assert ioneq[33, 5] == u.Quantity(0.5787345345914312)
+    assert u.allclose(ioneq[33, 5], u.Quantity(0.5787345345914312), atol=0.0, rtol=1e-10)
 
 
 def test_element_repr(element):

--- a/fiasco/util/setup_db.py
+++ b/fiasco/util/setup_db.py
@@ -114,6 +114,7 @@ def download_dbase(ascii_dbase_url, ascii_dbase_root):
 
 
 def md5hash(path):
+    # Use the md5 utility to generate this
     path = pathlib.Path(path)
     with path.open('rb') as f:
         return hashlib.md5(f.read()).hexdigest()

--- a/fiasco/util/util.py
+++ b/fiasco/util/util.py
@@ -110,7 +110,7 @@ def get_chianti_catalog(ascii_dbase_root):
 
         return subdir_files
 
-    non_ion_subdirs = ['abundance', 'ioneq', 'ip', 'continuum']
+    non_ion_subdirs = ['abundance', 'ioneq', 'ip', 'continuum', 'dem']
     all_files = {f'{sd}_files': walk_sub_dir(sd) for sd in non_ion_subdirs}
     all_files['ion_files'] = ion_files
 


### PR DESCRIPTION
This adds a parser (and HDF5 writer) for the various DEM files that are distributed with CHIANTI. Though these files can now be parsed and are added to the HDF5 database, it's not completely clear what the best way to expose this data is. This may be left to a separate PR.