### PR TITLE
Correct level populations for ionization and recombination processes

### DIFF
--- a/fiasco/conftest.py
+++ b/fiasco/conftest.py
@@ -84,6 +84,11 @@ TEST_FILES = {
     'fe_27.rrparams':                       '75383b0f1b167f862cfd26bbadd2a029',
     'fe_10.psplups':                        'dd34363f6daa81dbf106fbeb211b457d',
     'fe_10.elvlc':                          'f221d4c7167336556d57378ac368afc1',
+    'fe_20.elvlc':                          'bbddcf958dd41311ea24bf177c2b62de',
+    'fe_20.wgfa':                           'c991c30b98b03c9152ba5a2c71877149',
+    'fe_20.scups':                          'f0e375cad2ec8296efb2abcb8f02705e',
+    'fe_20.cilvl':                          'b71833c51a03c7073f1657ce60afcdbb',
+    'fe_20.reclvl':                         'cf28869709acef521fb6a1c9a2b59530',
 }
 
 

--- a/fiasco/ions.py
+++ b/fiasco/ions.py
@@ -6,7 +6,7 @@ import astropy.units as u
 import numpy as np
 
 from functools import cached_property
-from scipy.interpolate import interp1d, pchip_interpolate, splev, splrep
+from scipy.interpolate import interp1d, PchipInterpolator, splev, splrep
 from scipy.ndimage import map_coordinates
 
 from fiasco import proton_electron_ratio
@@ -173,19 +173,34 @@ Using Datasets:
         ionization equilibrium outside of this temperature range, it is better to use the ionization
         and recombination rates.
 
+        Note
+        ----
+        The cubic interpolation is performed in log-log spaceusing a Piecewise Cubic Hermite
+        Interpolating Polynomial with `~scipy.interpolate.PchipInterpolator`. This helps to
+        ensure smoothness while reducing oscillations in the interpolated ionization fractions.
+
         See Also
         --------
         fiasco.Element.equilibrium_ionization
         """
-        # FIXME: Needs explanation of why this interpolation scheme is used...
-        temperature = self.temperature.to_value('MK')
-        temperature_data = self._ioneq[self._dset_names['ioneq_filename']]['temperature'].to_value('MK')
+        temperature = self.temperature.to_value('K')
+        temperature_data = self._ioneq[self._dset_names['ioneq_filename']]['temperature'].to_value('K')
         ioneq_data = self._ioneq[self._dset_names['ioneq_filename']]['ionization_fraction'].value
-        ioneq = pchip_interpolate(temperature_data, ioneq_data, temperature)
-        out_of_bounds = np.logical_and(temperature<temperature_data.min(), temperature>temperature_data.max())
+        # Perform PCHIP interpolation in log-space on only the non-zero ionization fractions.
+        # See https://github.com/wtbarnes/fiasco/pull/223 for additional discussion.
+        is_nonzero = ioneq_data > 0.0
+        f_interp = PchipInterpolator(np.log10(temperature_data[is_nonzero]),
+                                     np.log10(ioneq_data[is_nonzero]),
+                                     extrapolate=False)
+        ioneq = f_interp(np.log10(temperature))
+        ioneq = 10**ioneq
+        # This sets all entries that would have interpolated to zero ionization fraction to zero
+        ioneq = np.where(np.isnan(ioneq), 0.0, ioneq)
+        # Set entries that are truly out of bounds of the original temperature data back to NaN
+        out_of_bounds = np.logical_or(temperature<temperature_data.min(), temperature>temperature_data.max())
         ioneq = np.where(out_of_bounds, np.nan, ioneq)
-        isfinite = np.isfinite(ioneq)
-        ioneq[isfinite] = np.where(ioneq[isfinite] < 0., 0., ioneq[isfinite])
+        is_finite = np.isfinite(ioneq)
+        ioneq[is_finite] = np.where(ioneq[is_finite] < 0., 0., ioneq[is_finite])
         return u.Quantity(ioneq)
 
     @property
@@ -530,16 +545,17 @@ Using Datasets:
         # last two points should be used. Thus, we need to perform two interpolations
         # for each level.
         # NOTE: In the CHIANTI IDL code, the interpolation is done using a cubic spline.
-        # However, here I've used a linear spline as I found that, for some of the
-        # recombination rates, this led to oscillations in the interpolated rates over
-        # some parts of the temperature range. Using a linear spline avoids this at the
-        # cost of having a less smooth correction factor.
+        # Here, the rates are interpolated using a Piecewise Cubic Hermite Interpolating
+        # Polynomial (PCHIP) which balances smoothness and also reduces the oscillations
+        # that occur with higher order spline fits. This is needed mostly due to the wide
+        # range over which this data is fit.
         temperature = self.temperature.to_value('K')
         rates = []
         for t, r in zip(temperature_table.to_value('K'), rate_table.to_value('cm3 s-1')):
-            # FIXME: This needs explanation...is it even worth it?
-            rate_interp = pchip_interpolate(t, r, temperature)
-            rate_interp = np.where(np.logical_and(temperature<t[0], temperature>t[-1]), 0, rate_interp)
+            rate_interp = PchipInterpolator(t, r, extrapolate=False)(temperature)
+            # NOTE: Anything outside of the temperature range will be set to NaN by the
+            # interpolation but we want these to be 0.
+            rate_interp = np.where(np.isnan(rate_interp), 0, rate_interp)
             if extrapolate_above:
                 f_extrapolate = interp1d(t[-2:], r[-2:], kind='linear', fill_value='extrapolate')
                 i_extrapolate = np.where(temperature > t[-1])
@@ -598,21 +614,25 @@ Using Datasets:
         correction: `np.ndarray`
             Correction factor to multiply populations by
         """
-        try:
-            upper_level_ionization, ionization_rate = self._level_resolved_ionization_rate
-            upper_level_recombination, recombination_rate = self._level_resolved_recombination_rate
-        except MissingDatasetException:
-            # The cilvl and reclvl files do not exist for this ion so there is no correction factor
-            return 1.0
-        # Ionization fraction of current and surrounding ions with appropriate shape
-        ioneq_current = self.ioneq.value[:, np.newaxis]
-        ioneq_previous = self.previous_ion().ioneq.value[:, np.newaxis]
-        ioneq_next = self.next_ion().ioneq.value[:, np.newaxis]
+        # NOTE: These are done in separate try/except blocks because some ions have just a cilvl file,
+        # some have just a reclvl file, and some have both.
+        # NOTE: Ioneq values for surrounding ions are retrieved afterwards because first and last ions do
+        # not have previous or next ions but also do not have reclvl or cilvl files.
         # NOTE: stripping the units off and adding them at the end because of some strange astropy
         # Quantity behavior that does not allow for adding these two compatible shapes together.
         numerator = np.zeros(population.shape)
-        numerator[:, upper_level_ionization-1] += (ionization_rate * ioneq_previous).to_value('cm3 s-1')
-        numerator[:, upper_level_recombination-1] += (recombination_rate * ioneq_next).to_value('cm3 s-1')
+        try:
+            upper_level_ionization, ionization_rate = self._level_resolved_ionization_rate
+            ioneq_previous = self.previous_ion().ioneq.value[:, np.newaxis]
+            numerator[:, upper_level_ionization-1] += (ionization_rate * ioneq_previous).to_value('cm3 s-1')
+        except MissingDatasetException:
+            pass
+        try:
+            upper_level_recombination, recombination_rate = self._level_resolved_recombination_rate
+            ioneq_next = self.next_ion().ioneq.value[:, np.newaxis]
+            numerator[:, upper_level_recombination-1] += (recombination_rate * ioneq_next).to_value('cm3 s-1')
+        except MissingDatasetException:
+            pass
         numerator *= density.to_value('cm-3')
 
         c = rate_matrix.to_value('s-1').copy()
@@ -622,7 +642,7 @@ Using Datasets:
         # Sum of the population-weighted excitations from lower levels
         # and cascades from higher levels
         denominator = np.einsum('ijk,ik->ij', c, population)
-        denominator *= ioneq_current
+        denominator *= self.ioneq.value[:, np.newaxis]
         # Set any zero entries to NaN to avoid divide by zero warnings
         denominator = np.where(denominator==0.0, np.nan, denominator)
 

--- a/fiasco/ions.py
+++ b/fiasco/ions.py
@@ -355,6 +355,7 @@ Using Datasets:
 
         See Also
         --------
+        proton_collision_deexcitation_rate
         electron_collision_excitation_rate
         """
         # Create scaled temperature--these are not stored in the file

--- a/fiasco/ions.py
+++ b/fiasco/ions.py
@@ -511,6 +511,36 @@ Using Datasets:
 
         return u.Quantity(populations)
 
+    @needs_dataset('cilvl', 'reclvl')
+    @u.quantity_input
+    def population_correction(self, population, density, rate_matrix):
+        """
+        Correct level population to account for ionization and
+        recombination processes.
+
+        Corrects the level population to account for ionization and
+        recombination processes.
+
+        Parameters
+        ----------
+        population
+        density
+        rate_matrix
+        """
+        # Interpolate rates
+        # NOTE: According to CHIANTI Technical Report No. 20, Section 5,
+        # the interpolation should be linear. For the recombination, the rates
+        # should be zero below the temperature range and above the temperature
+        # range, the last two points should be used to perform a linear
+        # extrapolation. For the ionization rates, the opposite should be done.
+        # NOTE: should construct a total denominator array and interpolate each to
+        # the appropriate temperature and insert them at the correct level.
+        # Compute numerator
+        # Compute denominator
+        # NOTE: all quantities should be on a grid that has dimensions n_temperature
+        # by n_levels, the same dimensions as the level populations
+        ...
+
     @needs_dataset('abundance', 'elvlc')
     @u.quantity_input
     def contribution_function(self, density: u.cm**(-3), **kwargs) -> u.cm**3 * u.erg / u.s:

--- a/fiasco/tests/idl/test_idl_ioneq.py
+++ b/fiasco/tests/idl/test_idl_ioneq.py
@@ -32,6 +32,7 @@ def ioneq_from_idl(idl_env, ascii_dbase_root):
     'C 2',
     'C 3',
     'Ca 2',
+    'Fe 20',
 ])
 def test_ioneq_from_idl(ion_name, ioneq_from_idl, hdf5_dbase_root):
     temperature = 10**ioneq_from_idl['ioneq_logt'] * u.K

--- a/fiasco/tests/test_collections.py
+++ b/fiasco/tests/test_collections.py
@@ -93,16 +93,18 @@ def test_length(collection):
 def test_free_free(another_collection, wavelength):
     ff = another_collection.free_free(wavelength)
     assert ff.shape == temperature.shape + wavelength.shape if wavelength.shape else (1,)
-    index = 50 if wavelength.shape else 0
-    assert u.allclose(ff[50, index], 3.19877384e-35 * u.Unit('erg cm3 s-1 Angstrom-1'))
+    index_w = 50 if wavelength.shape else 0
+    index_t = 24  # This is approximately where the ioneq for Fe V peaks
+    assert u.allclose(ff[index_t, index_w], 3.2914969734961024e-42 * u.Unit('erg cm3 s-1 Angstrom-1'))
 
 
 @pytest.mark.parametrize('wavelength', [wavelength, wavelength[50]])
 def test_free_bound(another_collection, wavelength):
     fb = another_collection.free_bound(wavelength)
     assert fb.shape == temperature.shape + wavelength.shape if wavelength.shape else (1,)
-    index = 50 if wavelength.shape else 0
-    assert u.allclose(fb[50, index], 3.2653516e-29 * u.Unit('erg cm3 s-1 Angstrom-1'))
+    index_w = 50 if wavelength.shape else 0
+    index_t = 24  # This is approximately where the ioneq for Fe V peaks
+    assert u.allclose(fb[index_t, index_w], 1.1573022245197259e-35 * u.Unit('erg cm3 s-1 Angstrom-1'))
 
 
 def test_radiative_los(collection):

--- a/fiasco/tests/test_ion.py
+++ b/fiasco/tests/test_ion.py
@@ -115,13 +115,21 @@ def test_no_elvlc_raises_index_error(hdf5_dbase_root):
 
 
 def test_ioneq(ion):
-    assert ion.ioneq.shape == temperature.shape
     t_data = ion._ioneq[ion._dset_names['ioneq_filename']]['temperature']
     ioneq_data = ion._ioneq[ion._dset_names['ioneq_filename']]['ionization_fraction']
-    i_t = np.where(t_data == ion.temperature[0])
-    # Essentially test that we've done the interpolation to the data correctly
-    # for a single value
-    assert u.allclose(ion.ioneq[0], ioneq_data[i_t])
+    ion_at_nodes = ion._new_instance(temperature=t_data)
+    assert u.allclose(ion_at_nodes.ioneq, ioneq_data, rtol=1e-6)
+
+
+def test_ioneq_positive(ion):
+    assert np.all(ion.ioneq >= 0)
+
+
+def test_ioneq_out_bounds_is_nan(ion):
+    t_data = ion._ioneq[ion._dset_names['ioneq_filename']]['temperature']
+    t_out_of_bounds = t_data[[0,-1]] + [-100, 1e6] * u.K
+    ion_out_of_bounds = ion._new_instance(temperature=t_out_of_bounds)
+    assert np.isnan(ion_out_of_bounds.ioneq).all()
 
 
 def test_formation_temeprature(ion):


### PR DESCRIPTION
Fixes #24 

This PR accomplishes two main things:

1. It implements the correction to the level populations calculation by incorporating processes due to level-resolved ionization and recombination as stored in the `cilvl` and `reclvl` files as described in Landi et al. (2006)
2. It fixes the interpolation of the ionization equilibrium by switching the interpolation from linear to a Piecewise Cubic Hermite Interpolating Polynomial (PCHIP) approach. This is more accurate over the full temperature range and even for small ionization fractions.

A few remaining TODOs:

- [x] Tests that compare level populations with and without correction factor (note that this may involve adding another file to the test dataset as few actually have cilvl and reclvl files). This should test that only the levels inlcuded in those files are modified in the level populations calculation.
- [x] Deal with divide-by-zero warning in numerator calculation in correction factor
- [x] Docstring for level populations
- [x] Clarifying comments where needed regarding interpolation methods
- [x] Run IDL comparison checks against continuum results to ensure ioneq interpolation has not caused a regression
- [x] Compare against Fe XX correction factor from v8 IDL code