### PR TITLE
Refactor `psplups` treatment in `level_populations` and add test for full database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,16 @@ jobs:
       cache-key: chianti-${{ github.event.number }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  test_full_database:
+    needs: [test]
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      posargs: '--ascii-dbase-root ~/.chianti --include-all-files'
+      toxdeps: "'tox<4' tox-pypi-filter"
+      envs: |
+        - linux: py310
+      cache-path: ~/.chianti
+      cache-key: chianti-${{ github.event.number }}
   precommit:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
@@ -57,7 +67,7 @@ jobs:
         github.event_name == 'pull_request' &&
         contains(github.event.pull_request.labels.*.name, 'Run publish')
       )
-    needs: [test]
+    needs: [test,test_full_database]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@main
     with:
       test_extras: 'dev'

--- a/conftest.py
+++ b/conftest.py
@@ -11,6 +11,6 @@ def pytest_addoption(parser):
                      help='Disable MD5 hash checks on test files')
     parser.addoption('--idl-executable', action='store', default=None)
     parser.addoption('--idl-codebase-root', action='store', default=None)
-    parser.addoption('--include-all-files', action='store', default=False)
+    parser.addoption('--include-all-files', action='store_true', default=False)
     parser.addoption('--skip-version-check', action='store_true', default=False,
                      help='Do not check CHIANTI version')

--- a/fiasco/conftest.py
+++ b/fiasco/conftest.py
@@ -31,6 +31,7 @@ TEST_FILES = {
     'h_1.wgfa':                             'ed2a561ecdba5ee4b05ea56c297724ba',
     'h_1.scups':                            'de180c9e1b4f50a503efad8c83e714ab',
     'h_1.diparams':                         'f9be79794cc092c75733ece7aba9f29f',
+    'h_1.fblvl':                            'af45fd1ee7af4b4e71aba288d0b16bc8',
     'h_2.rrparams':                         '05eb5044dc1ad070338d1ba3745dc4de',
     'he_1.elvlc':                           '577245da46cfc4d27a05f40147f17610',
     'he_2.elvlc':                           '58eee740f6842850f1f35a4f95b3e12c',

--- a/fiasco/conftest.py
+++ b/fiasco/conftest.py
@@ -71,6 +71,7 @@ TEST_FILES = {
     'fe_5.wgfa':                            '6f8e4d41760d5a0540008e15aca1038c',
     'fe_6.elvlc':                           '081519f986b8a8ed99a34ecf813f1358',
     'fe_6.fblvl':                           '9478aeab2479e9eefebfd1e552e27ddf',
+    'fe_7.fblvl':                           'ad0264f06018b0b9cca1eba502809708',
     'fe_9.elvlc':                           'b7d04f65a87a8de1c2bfc77331e438f3',
     'fe_12.elvlc':                          'ee9beb8b2ff03ba8fc046bd722992b21',
     'fe_15.elvlc':                          'cb8e6291bac17325130ea8564e118d48',

--- a/fiasco/tests/test_collections.py
+++ b/fiasco/tests/test_collections.py
@@ -104,7 +104,7 @@ def test_free_bound(another_collection, wavelength):
     assert fb.shape == temperature.shape + wavelength.shape if wavelength.shape else (1,)
     index_w = 50 if wavelength.shape else 0
     index_t = 24  # This is approximately where the ioneq for Fe V peaks
-    assert u.allclose(fb[index_t, index_w], 1.1573022245197259e-35 * u.Unit('erg cm3 s-1 Angstrom-1'))
+    assert u.allclose(fb[index_t, index_w], 3.057781475607237e-36 * u.Unit('erg cm3 s-1 Angstrom-1'))
 
 
 def test_radiative_los(collection):

--- a/fiasco/tests/test_ion.py
+++ b/fiasco/tests/test_ion.py
@@ -23,6 +23,11 @@ def another_ion(hdf5_dbase_root):
 
 
 @pytest.fixture
+def h1(hdf5_dbase_root):
+    return fiasco.Ion('H 1', temperature, hdf5_dbase_root=hdf5_dbase_root)
+
+
+@pytest.fixture
 def fe10(hdf5_dbase_root):
     return fiasco.Ion('Fe 10', temperature, hdf5_dbase_root=hdf5_dbase_root)
 
@@ -312,6 +317,15 @@ def test_free_bound(ion):
     assert emission.shape == ion.temperature.shape + (1, )
     # This value has not been tested for correctness
     assert u.allclose(emission[0, 0], 9.7902609e-26 * u.cm**3 * u.erg / u.Angstrom / u.s)
+
+
+def test_free_bound_no_recombining(h1):
+    # This is test the case where there is no data available for the recombining
+    # ion (H 2)
+    emission = h1.free_bound(200 * u.Angstrom)
+    assert emission.shape == h1.temperature.shape + (1, )
+        # This value has not been tested for correctness
+    assert u.allclose(emission[0, 0], 1.9611545671496785e-28 * u.cm**3 * u.erg / u.Angstrom / u.s)
 
 
 def test_add_ions(ion, another_ion):

--- a/fiasco/tests/test_ion.py
+++ b/fiasco/tests/test_ion.py
@@ -180,6 +180,13 @@ def test_level_populations(ion):
     assert u.allclose(pop.squeeze().sum(axis=1), 1, atol=None, rtol=1e-15)
 
 
+def test_level_populations_proton_data_toggle(ion):
+    # Fe V has no psplups data so the toggle should have no effect
+    lp_protons = ion.level_populations(1e9*u.cm**(-3), include_protons=True)
+    lp_no_protons = ion.level_populations(1e9*u.cm**(-3), include_protons=False)
+    assert u.allclose(lp_protons, lp_no_protons, atol=0, rtol=0)
+
+
 def test_contribution_function(ion):
     cont_func = ion.contribution_function(1e7 * u.cm**-3)
     assert cont_func.shape == ion.temperature.shape + (1, ) + ion._wgfa['wavelength'].shape


### PR DESCRIPTION
Fixes #228 
Fixes #227 
Fixes #220 

This PR does some minor refactoring to the level populations for handling the proton rates and also adds a test on the CI for the whole database.