### PR TITLE
Add file reader for autoionization files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,6 @@ jobs:
       toxdeps: "'tox<4' tox-pypi-filter"
       envs: |
         - linux: py310
-  test_database_v10:
-    needs: [test]
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
-    with:
-      posargs: '--ascii-dbase-root ~/.chianti --ascii-dbase-url http://download.chiantidatabase.org/CHIANTI_10.1_database.tar.gz --disable-file-hash --skip-version-check'
-      toxdeps: "'tox<4' tox-pypi-filter"
-      envs: |
-        - linux: py310
   precommit:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,7 @@ jobs:
       posargs: '--ascii-dbase-root ~/.chianti'
       toxdeps: "'tox<4' tox-pypi-filter"
       envs: |
-        - macos: py38
         - macos: py310
-        - windows: py38
         - windows: py310
         - linux: py38
         - linux: py39
@@ -40,6 +38,22 @@ jobs:
         - linux: py310
       cache-path: ~/.chianti
       cache-key: chianti-${{ github.event.number }}
+  test_database_v9:
+    needs: [test]
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      posargs: '--ascii-dbase-root ~/.chianti --ascii-dbase-url http://download.chiantidatabase.org/CHIANTI_v9.0.1_database.tar.gz --disable-file-hash --skip-version-check'
+      toxdeps: "'tox<4' tox-pypi-filter"
+      envs: |
+        - linux: py310
+  test_database_v10:
+    needs: [test]
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      posargs: '--ascii-dbase-root ~/.chianti --ascii-dbase-url http://download.chiantidatabase.org/CHIANTI_10.1_database.tar.gz --disable-file-hash --skip-version-check'
+      toxdeps: "'tox<4' tox-pypi-filter"
+      envs: |
+        - linux: py310
   precommit:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -404,3 +404,13 @@
   issn = {0004-6361},
   doi = {10.1051/0004-6361:20031462}
 }
+
+@techreport{dere_chianti_2017,
+  title = {{{CHIANTI Technical Report No}}. 8: {{The CHIANTI}} Autoionization Rate Files (Auto)},
+  author = {Dere, K. P.},
+  year = {2017},
+  month = dec,
+  number = {8},
+  urldate = {2022-08-21},
+  langid = {english}
+}

--- a/fiasco/io/generic.py
+++ b/fiasco/io/generic.py
@@ -13,6 +13,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 import fiasco
 
 from fiasco.util.exceptions import MissingASCIIFileError
+from fiasco.util.util import read_chianti_version
 
 
 class GenericParser:
@@ -32,10 +33,8 @@ class GenericParser:
         if standalone:
             self.chianti_version = ''
         else:
-            version_file = self.ascii_dbase_root / 'VERSION'
-            with version_file.open() as f:
-                lines = f.readlines()
-                self.chianti_version = lines[0].strip()
+            version = read_chianti_version(self.ascii_dbase_root)
+            self.chianti_version = f"{version['major']}.{version['minor']}.{version['patch']}"
         self.full_path = pathlib.Path(filename) if standalone else self.ascii_dbase_root / self.filename
 
     def parse(self):

--- a/fiasco/io/sources/ion_sources.py
+++ b/fiasco/io/sources/ion_sources.py
@@ -416,3 +416,26 @@ class DiparamsParser(GenericIonParser):
             ionization_potential = tmp[0]
             cs_spline = np.array(tmp[1:], dtype=float)*1e-14
             table[-1] = [ionization_potential] + table[-1] + [cs_spline] + [0.0]
+
+
+class AutoParser(GenericIonParser):
+    """
+    Autoionization rates for each level in an ion
+    """
+    filetype = 'auto'
+    dtypes = [int, int, float, str, str]
+    units = [None, None, 1/u.s, None, None]
+    headings = ['lower_level', 'upper_level', 'autoionization_rate', 'lower_label', 'upper_label']
+    descriptions = [
+        'lower level index', 
+        'upper level index', 
+        'autoionization rate', 
+        'lower level label', 
+        'upper level label'
+    ]
+    fformat = fortranformat.FortranRecordReader('(2I7,E12.2,A30,A30)')
+
+    def preprocessor(self, table, line, index):
+        super().preprocessor(table, line, index)
+        # remove the dash in the second-to-last entry
+        table[-1][-2] = table[-1][-2].split('-')[0].strip()

--- a/fiasco/io/sources/ion_sources.py
+++ b/fiasco/io/sources/ion_sources.py
@@ -425,12 +425,18 @@ class AutoParser(GenericIonParser):
     filetype = 'auto'
     dtypes = [int, int, float, str, str]
     units = [None, None, 1/u.s, None, None]
-    headings = ['lower_level', 'upper_level', 'autoionization_rate', 'lower_label', 'upper_label']
+    headings = [
+        'lower_level',
+        'upper_level',
+        'autoionization_rate',
+        'lower_label',
+        'upper_label'
+    ]
     descriptions = [
-        'lower level index', 
-        'upper level index', 
-        'autoionization rate', 
-        'lower level label', 
+        'lower level index',
+        'upper level index',
+        'autoionization rate',
+        'lower level label',
         'upper level label'
     ]
     fformat = fortranformat.FortranRecordReader('(2I7,E12.2,A30,A30)')

--- a/fiasco/io/sources/ion_sources.py
+++ b/fiasco/io/sources/ion_sources.py
@@ -7,11 +7,22 @@ import numpy as np
 
 from fiasco.io.generic import GenericIonParser
 
-__all__ = ['ElvlcParser', 'FblvlParser', 'ScupsParser',
-           'PsplupsParser', 'EasplomParser', 'EasplupsParser',
-           'WgfaParser', 'CilvlParser', 'ReclvlParser',
-           'RrparamsParser', 'TrparamsParser', 'DrparamsParser',
-           'DiparamsParser']
+__all__ = [
+    'ElvlcParser',
+    'FblvlParser',
+    'ScupsParser',
+    'PsplupsParser',
+    'EasplomParser',
+    'EasplupsParser',
+    'WgfaParser',
+    'CilvlParser',
+    'ReclvlParser',
+    'RrparamsParser',
+    'TrparamsParser',
+    'DrparamsParser',
+    'DiparamsParser',
+    'AutoParser',
+]
 
 
 class ElvlcParser(GenericIonParser):
@@ -420,12 +431,12 @@ class DiparamsParser(GenericIonParser):
 
 class AutoParser(GenericIonParser):
     """
-    Autoionization rates for each level in an ion.  
-    
-    For full description, see http://www.chiantidatabase.org/tech_reports/08_auto/chianti_report_8.pdf 
-    The autoionization rate is the rate of decay of atomic level through autoionization to a 
-    bound level.  It is also needed to calculate the dielectronic recombination rate
+    Autoionization rates for each level in an ion.
+
+    The autoionization rate is the rate of decay of atomic level through autoionization to a
+    bound level. It is also needed to calculate the dielectronic recombination rate
     from the more highly ionized ions, by means of the principle of detailed-balance.
+    For a full description of these files, see :cite:t:`dere_chianti_2017`.
     """
     filetype = 'auto'
     dtypes = [int, int, float, str, str]

--- a/fiasco/io/sources/tests/test_sources.py
+++ b/fiasco/io/sources/tests/test_sources.py
@@ -22,6 +22,7 @@ import fiasco.io
     'fe_2.trparams',
     'fe_12.drparams',
     'al_3.diparams',
+    'fe_23.auto',
 ])
 def test_ion_sources(ascii_dbase_root, filename,):
     parser = fiasco.io.Parser(filename, ascii_dbase_root=ascii_dbase_root)

--- a/fiasco/io/sources/tests/test_sources.py
+++ b/fiasco/io/sources/tests/test_sources.py
@@ -22,7 +22,7 @@ import fiasco.io
     'fe_2.trparams',
     'fe_12.drparams',
     'al_3.diparams',
-    'fe_23.auto',
+    pytest.param('fe_23.auto', marks=pytest.mark.requires_dbase_version('>=9')),
 ])
 def test_ion_sources(ascii_dbase_root, filename,):
     parser = fiasco.io.Parser(filename, ascii_dbase_root=ascii_dbase_root)

--- a/fiasco/tests/test_ion.py
+++ b/fiasco/tests/test_ion.py
@@ -244,6 +244,7 @@ def test_level_populations_normalized(pops_no_correction, pops_with_correction):
     assert u.allclose(pops_no_correction.sum(axis=1), 1, atol=None, rtol=1e-15)
 
 
+@pytest.mark.requires_dbase_version('<=8')
 def test_level_populations_correction(fe20, pops_no_correction, pops_with_correction):
     # Test level-resolved correction applied to correct levels
     i_corrected = np.unique(np.concatenate([fe20._cilvl['upper_level'], fe20._reclvl['upper_level']]))

--- a/fiasco/util/tests/test_util.py
+++ b/fiasco/util/tests/test_util.py
@@ -3,7 +3,7 @@ Tests for util functions
 """
 import pytest
 
-from fiasco.util import get_chianti_catalog, parse_ion_name
+from fiasco.util import get_chianti_catalog, parse_ion_name, read_chianti_version
 
 
 @pytest.mark.parametrize('ion_name', [
@@ -35,3 +35,11 @@ def test_get_chianti_catalog(ascii_dbase_root):
     for k in keys:
         assert k in catalog
         assert isinstance(catalog[k], list)
+
+
+def test_chianti_version(ascii_dbase_root):
+    version = read_chianti_version(ascii_dbase_root)
+    assert isinstance(version, dict)
+    for k in ['major', 'minor', 'patch']:
+        assert k in version
+        assert isinstance(version[k], int)

--- a/fiasco/util/util.py
+++ b/fiasco/util/util.py
@@ -12,7 +12,7 @@ from plasmapy.utils import roman
 FIASCO_HOME = pathlib.Path.home() / '.fiasco'
 FIASCO_RC = FIASCO_HOME / 'fiascorc'
 
-__all__ = ['setup_paths', 'get_chianti_catalog', 'parse_ion_name']
+__all__ = ['setup_paths', 'get_chianti_catalog', 'read_chianti_version', 'parse_ion_name']
 
 
 def parse_ion_name(ion_name):
@@ -115,6 +115,28 @@ def get_chianti_catalog(ascii_dbase_root):
     all_files['ion_files'] = ion_files
 
     return all_files
+
+
+def read_chianti_version(ascii_dbase_root):
+    """
+    Read the CHIANTI version number from the ASCII database.
+    """
+    version_file = pathlib.Path(ascii_dbase_root) / 'VERSION'
+    with version_file.open() as f:
+        lines = f.readlines()
+    version = lines[0].strip().split('.')
+    version_dict = {'major': 0, 'minor': 0, 'patch': 0}
+    n = len(version)
+    if n > 0:
+        version_dict['major'] = int(version[0])
+    if n > 1:
+        version_dict['minor'] = int(version[1])
+    if n > 2:
+        version_dict['patch'] = int(version[2])
+    if n > 3:
+        import fiasco
+        fiasco.log.warning(f'Version {version} has an unexpected number of entries.')
+    return version_dict
 
 
 def query_yes_no(question, default="yes"):


### PR DESCRIPTION
Fixes #48 

Adds the function to read the files.  I'm not sure where that would then need to be called within fiasco itself.

Tested with the .auto files in CHIANTI v10:

```
(base) C:\Users\reep\Documents>python
Python 3.11.5 | packaged by Anaconda, Inc. | (main, Sep 11 2023, 13:26:23) [MSC v.1916 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> from astropy.table import QTable
>>>
>>> import fiasco.io
>>> paser = fiasco.io.Parser('fe_23.auto')
>>> table = paser.parse()
>>> table
<QTable length=84>
lower_level upper_level autoionization_rate lower_label     upper_label
                               1 / s
   int32       int32          float64          str12           str17
----------- ----------- ------------------- ------------ -----------------
          1         167    62100000000000.0 1s2.2s 2S0.5 - 1s.2s2.2p 3P0.0
          3         167     3970000000000.0 1s2.2p 2P1.5 - 1s.2s2.2p 3P0.0
          2         167   123000000000000.0 1s2.2p 2P0.5 - 1s.2s2.2p 3P0.0
          1         168    58100000000000.0 1s2.2s 2S0.5 - 1s.2s2.2p 3P1.0
          3         168    19200000000000.0 1s2.2p 2P1.5 - 1s.2s2.2p 3P1.0
          2         168   108000000000000.0 1s2.2p 2P0.5 - 1s.2s2.2p 3P1.0
          1         169    61400000000000.0 1s2.2s 2S0.5 - 1s.2s2.2p 3P2.0
          3         169   127000000000000.0 1s2.2p 2P1.5 - 1s.2s2.2p 3P2.0
          2         169     3200000000000.0 1s2.2p 2P0.5 - 1s.2s2.2p 3P2.0
        ...         ...                 ...          ...               ...
          2         193    19700000000000.0 1s2.2p 2P0.5    - 1s.2p3 3P0.0
          1         194     1710000000000.0 1s2.2s 2S0.5    - 1s.2p3 3P1.0
          3         194   108000000000000.0 1s2.2p 2P1.5    - 1s.2p3 3P1.0
          2         194    15900000000000.0 1s2.2p 2P0.5    - 1s.2p3 3P1.0
          1         195     1290000000000.0 1s2.2s 2S0.5    - 1s.2p3 3P2.0
          3         195   156000000000000.0 1s2.2p 2P1.5    - 1s.2p3 3P2.0
          2         195     4290000000000.0 1s2.2p 2P0.5    - 1s.2p3 3P2.0
          1         196      119000000000.0 1s2.2s 2S0.5    - 1s.2p3 1P1.0
          3         196   107000000000000.0 1s2.2p 2P1.5    - 1s.2p3 1P1.0
          2         196    18600000000000.0 1s2.2p 2P0.5    - 1s.2p3 1P1.0
>>> table.meta
OrderedDict([('footer', "filename:  fe_23.auto\nTheoretical energy levels and autoionization rates:  Autostructure calculation\nA Breit-Pauli distorted wave implementation for AUTOSTRUCTURE\nBadnell, N.R., 2011, Computer Physics Communications, 182, 1528\nADSref:  http://adsabs.harvard.edu/abs/2011CoPhC.182.1528B\nAutostructure calculation optimized with 'SHFTIC' file using energy corrections from the following sources:\nObserved energy levels:  Kramida, A., Ralchenko, Yu., Reader, J., and NIST ASD Team (2012). NIST Atomic Spectra Database (ver. 5.0), [Online]. Available: http://physics.nist.gov/asd [2012, September 14]. National Institute of Standards and Technology, Gaithersburg, MD.\ntheoretical energy levels used to correct autostructure levels\nYerokhin, V. A.; Surzhykov, A.; Fritzsche, S.\nRelativistic configuration-interaction calculation of K-alpha transition energies in berylliumlike iron\nPhysical Review A, Volume 90, Issue 2, id.022509\nDOI:  10.1103/PhysRevA.90.022509\nadsRef:  http://adsabs.harvard.edu/abs/2014PhRvA..90b2509Y\nobserved energy levels 168 ( 53215318.) and 173 (53464915.) from\nRudolph, J. K.; Bernitt, S.; Epp, S. W.; Steinbrugge, R.; Beilmann, C.; Brown, G. V.; Eberle, S.; Graf, A.; Harman, Z.; Hell, N.; Leutenegger, M.; Mueller, A.; Schlage, K.; Wille, H.-C.; Yavas, H.; Ullrich, J.; Crespo Lopez-Urrutia, J. R.\nX-Ray Resonant Photoexcitation: Linewidths and Energies of K-alpha Transitions in Highly Charged Fe Ions\nPhysical Review Letters, vol. 111, Issue 10, id. 103002\nDOI:  10.1103/PhysRevLett.111.103002\nadsRef:  http://adsabs.harvard.edu/abs/2013PhRvL.111j3002R\nproduced as a part of the  'CHIANTI' atomic database for astrophysical spectroscopy\nK. Dere (GMU) - 2017 December 24\ncomment: Fixed text problem in comments. No change to data.  Peter Young, 25-Jul-2019"), ('chianti_version', '8.0.7'), ('filename', 'fe_23.auto'), ('descriptions', {'lower_level': 'lower level index', 'upper_level': 'upper level index', 'autoionization_rate': 'autoionization rate', 'lower_label': 'lower level label', 'upper_label': 'upper level label'}), ('element', 'fe'), ('ion', 'fe_23'), ('dielectronic', False)])
```