### PR TITLE
Add file reader for rrlvl files

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -414,3 +414,12 @@
   urldate = {2022-08-21},
   langid = {english}
 }
+
+@techreport{young_chianti_2019,
+  title = {{{CHIANTI Technical Report No}}. 24: {{The CHIANTI}} Level-Resolved Recombination Files (Rrlvl)},
+  author = {Young, Peter R.},
+  year = {2019},
+  month = feb,
+  number = {24},
+  urldate = {2024-01-09}
+}

--- a/fiasco/io/sources/ion_sources.py
+++ b/fiasco/io/sources/ion_sources.py
@@ -22,6 +22,7 @@ __all__ = [
     'DrparamsParser',
     'DiparamsParser',
     'AutoParser',
+    'RrlvlParser',
 ]
 
 

--- a/fiasco/io/sources/ion_sources.py
+++ b/fiasco/io/sources/ion_sources.py
@@ -461,3 +461,39 @@ class AutoParser(GenericIonParser):
         super().preprocessor(table, line, index)
         # remove the dash in the second-to-last entry
         table[-1][-2] = table[-1][-2].split('-')[0].strip()
+
+class RrlvlParser(GenericIonParser):
+    """
+    *Direct* radiative recombination rates from the recombining ion to the recombined ion.  
+    (N.B. .reclvl files contain *effective* radiation recombination rate coefficients.  
+    A given ion should have either a rrlvl file or a reclvl file, but not both.)
+    
+    For a full description of these files, see :cite:t:`dere_chianti_2017`.
+    """
+    filetype = 'rrlvl'
+    dtypes = [int, int, float, float]
+    units = [None, None, u.K, (u.cm**3)/u.s]
+    headings = [
+        'lower_level', 
+        'upper_level', 
+        'temperature', 
+        'recombination_rate'
+    ]
+    descriptions = [
+        'lower level index', 
+        'upper level index', 
+        'temperature', 
+        'recombination rate coefficient'
+    ]
+
+    def preprocessor(self, table, line, index):
+        line = line.strip().split()
+        if index % 2 == 0:
+            row = line[2:4]
+            temperature = np.array(line[4:], dtype=float)
+            row += [temperature]
+            table.append(row)
+        else:
+            rate_coefficient = np.array(line[4:], dtype=float)
+            table[-1].append(rate_coefficient)
+    

--- a/fiasco/io/sources/tests/test_sources.py
+++ b/fiasco/io/sources/tests/test_sources.py
@@ -23,6 +23,7 @@ import fiasco.io
     'fe_12.drparams',
     'al_3.diparams',
     pytest.param('fe_23.auto', marks=pytest.mark.requires_dbase_version('>=9')),
+    pytest.param('fe_23.rrlvl', marks=pytest.mark.requires_dbase_version('>=9')),
 ])
 def test_ion_sources(ascii_dbase_root, filename,):
     parser = fiasco.io.Parser(filename, ascii_dbase_root=ascii_dbase_root)


### PR DESCRIPTION
Fixes #114 

Tested with data from CHIANTI v10.

```
(base) C:\Users\reep\Documents\Forks\fiasco>python
Python 3.11.5 | packaged by conda-forge | (main, Aug 27 2023, 03:23:48) [MSC v.1936 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> from astropy.table import QTable
>>> import fiasco.io
>>> parser = fiasco.io.Parser('fe_23.rrlvl')
>>> table = parser.parse()
>>> table
<QTable length=459>
lower_level upper_level      temperature        recombination_rate
                                  K                  cm3 / s
   int32       int32         float64[19]           float64[19]
----------- ----------- ---------------------- --------------------
          1           1 5290.0 .. 5290000000.0 9.54e-12 .. 6.54e-16
          1           2 5290.0 .. 5290000000.0 4.93e-12 .. 4.18e-17
          1           3 5290.0 .. 5290000000.0 1.47e-11 .. 1.25e-16
          1           4 5290.0 .. 5290000000.0 2.41e-11 .. 2.07e-16
          1           5 5290.0 .. 5290000000.0 1.37e-11 .. 1.22e-16
          1           6 5290.0 .. 5290000000.0  4.2e-14 .. 3.39e-18
          1           7 5290.0 .. 5290000000.0 2.77e-13 .. 2.43e-17
          1           8 5290.0 .. 5290000000.0 4.69e-12 .. 2.97e-16
          1           9 5290.0 .. 5290000000.0 1.51e-12 .. 9.87e-17
        ...         ...                    ...                  ...
          3         153 5290.0 .. 5290000000.0 1.05e-12 .. 8.85e-19
          3         155 5290.0 .. 5290000000.0 3.78e-13 .. 1.59e-19
          3         165 5290.0 .. 5290000000.0 5.29e-13 .. 2.23e-19
          3         158 5290.0 .. 5290000000.0  6.8e-13 .. 2.87e-19
          3         160 5290.0 .. 5290000000.0  8.32e-13 .. 3.5e-19
          3         162 5290.0 .. 5290000000.0 5.29e-13 .. 2.23e-19
          3         159 5290.0 .. 5290000000.0  6.8e-13 .. 2.87e-19
          3         161 5290.0 .. 5290000000.0  8.32e-13 .. 3.5e-19
          3         163 5290.0 .. 5290000000.0 9.83e-13 .. 4.14e-19
          3         166 5290.0 .. 5290000000.0  1.87e-13 .. 4.5e-20
>>> table.meta
OrderedDict([('footer', "filename:  fe_23.rrlvl\nRadiative recombination rates for recombination onto Fe XXIV to form Fe XXIII\nBadnell, N. R., 2006, ApJS, 167, 334\nRadiative Recombination Data for Modeling Dynamic Finite-Density Plasmas\nadsLink:  http://adsabs.harvard.edu/abs/2006ApJS..167..334B\nproduced as a part of the 'CHIANTI' atomic database for astrophysical spectroscopy\nK. Dere (GMU) - 2018 December 15\nChanged indexing for v.10.\nProduced as part of the 'CHIANTI' atomic data base collaboration by\nGiulio Del Zanna, May 2020"), ('chianti_version', '8.0.7'), ('filename', 'fe_23.rrlvl'), ('descriptions', {'lower_level': 'lower level index', 'upper_level': 'upper level index', 'temperature': 'temperature', 'recombination_rate': 'recombination rate coefficient'}), ('element', 'fe'), ('ion', 'fe_23'), ('dielectronic', False)])
>>>
```