### PR TITLE
Add functionality to allow user to modify abundances

### DIFF
--- a/fiasco/base.py
+++ b/fiasco/base.py
@@ -143,7 +143,7 @@ class IonBase(Base):
     """
 
     @property
-    def _abundance(self):
+    def _abund(self):
         data_path = '/'.join([self.atomic_symbol.lower(), 'abundance'])
         return DataIndexer.create_indexer(self.hdf5_dbase_root, data_path)
 

--- a/fiasco/conftest.py
+++ b/fiasco/conftest.py
@@ -20,6 +20,7 @@ else:
 TEST_FILES = {
     'sun_coronal_1992_feldman_ext.abund',
     'sun_coronal_1992_feldman.abund',
+    'sun_photospheric_2007_grevesse.abund',
     'chianti.ip',
     'chianti.ioneq',
     'gffgu.dat',

--- a/fiasco/elements.py
+++ b/fiasco/elements.py
@@ -63,8 +63,8 @@ class Element(fiasco.IonCollection):
 
     @abundance.setter
     def abundance(self, abundance):
-        for i in range(self.atomic_number + 1):
-            self[i].abundance = abundance
+        for _ion in self:
+            _ion.abundance = abundance
 
     @cached_property
     def _rate_matrix(self):

--- a/fiasco/elements.py
+++ b/fiasco/elements.py
@@ -63,9 +63,14 @@ class Element(fiasco.IonCollection):
 
     @abundance.setter
     def abundance(self, abundance):
-        for i in range(self.atomic_number + 1):
-            self[i]._abundance = abundance
-        self._abundance = abundance
+        if isinstance(abundance, str):
+            self[0]._dset_names['abundance'] = abundance
+            self[0]._abundance = self[0]._abund[self[0]._dset_names['abundance']]
+        else:
+            self[0]._abundance = abundance
+        for i in range(1, self.atomic_number + 1):
+            self[i]._abundance = self[0]._abundance
+        self._abundance = self[0]._abundance
 
     @cached_property
     def _rate_matrix(self):

--- a/fiasco/elements.py
+++ b/fiasco/elements.py
@@ -29,7 +29,7 @@ class Element(fiasco.IonCollection):
     temperature : `~astropy.units.Quantity`
 
     See Also
-    --------
+    --------clTabCtrl
     fiasco.Ion : All the same keyword arguments can also be passed here.
     """
 
@@ -60,6 +60,12 @@ class Element(fiasco.IonCollection):
     @property
     def abundance(self):
         return self[0].abundance
+        
+    @abundance.setter
+    def abundance(self, abundance):
+        for i in range(self.atomic_number + 1):
+            self[i]._abundance = abundance
+        self._abundance = abundance
 
     @cached_property
     def _rate_matrix(self):

--- a/fiasco/elements.py
+++ b/fiasco/elements.py
@@ -63,14 +63,8 @@ class Element(fiasco.IonCollection):
 
     @abundance.setter
     def abundance(self, abundance):
-        if isinstance(abundance, str):
-            self[0]._dset_names['abundance'] = abundance
-            self[0]._abundance = self[0]._abund[self[0]._dset_names['abundance']]
-        else:
-            self[0]._abundance = abundance
-        for i in range(1, self.atomic_number + 1):
-            self[i]._abundance = self[0]._abundance
-        self._abundance = self[0]._abundance
+        for i in range(self.atomic_number + 1):
+            self[i].abundance = abundance
 
     @cached_property
     def _rate_matrix(self):

--- a/fiasco/elements.py
+++ b/fiasco/elements.py
@@ -60,7 +60,7 @@ class Element(fiasco.IonCollection):
     @property
     def abundance(self):
         return self[0].abundance
-        
+
     @abundance.setter
     def abundance(self, abundance):
         for i in range(self.atomic_number + 1):

--- a/fiasco/elements.py
+++ b/fiasco/elements.py
@@ -29,7 +29,7 @@ class Element(fiasco.IonCollection):
     temperature : `~astropy.units.Quantity`
 
     See Also
-    --------clTabCtrl
+    --------
     fiasco.Ion : All the same keyword arguments can also be passed here.
     """
 

--- a/fiasco/fiasco.py
+++ b/fiasco/fiasco.py
@@ -83,7 +83,7 @@ def proton_electron_ratio(temperature: u.K, **kwargs):
         try:
             abundance = el.abundance
         except KeyError:
-            abund_file = el[0]._instance_kwargs['abundance_filename']
+            abund_file = el[0]._instance_kwargs['abundance']
             log.warning(
                 f'Not including {el.atomic_symbol}. Abundance not available from {abund_file}.')
             continue

--- a/fiasco/ions.py
+++ b/fiasco/ions.py
@@ -42,8 +42,9 @@ class Ion(IonBase, ContinuumBase):
         Temperature array over which to evaluate temperature dependent quantities.
     ioneq_filename : `str`, optional
         Ionization equilibrium dataset
-    abundance_filename : `str`, optional
-        Abundance dataset
+    abundance : `str` or `float`, optional
+        If a string is provided, use the appropriate abundance dataset.  
+        If a float is provided, use that value as the abundance.
     ip_filename : `str`, optional
         Ionization potential dataset
     """
@@ -56,9 +57,13 @@ class Ion(IonBase, ContinuumBase):
         # TODO: do not hardcode defaults, pull from rc file
         self._dset_names = {}
         self._dset_names['ioneq_filename'] = kwargs.get('ioneq_filename', 'chianti')
-        self._dset_names['abundance_filename'] = kwargs.get('abundance_filename',
-                                                            'sun_coronal_1992_feldman_ext')
         self._dset_names['ip_filename'] = kwargs.get('ip_filename', 'chianti')
+        abund = kwargs.get('abundance', 'sun_coronal_1992_feldman_ext')
+        if isinstance(abund, str):
+            self._dset_names['abundance'] = abund
+            self.abundance = self._abund[self._dset_names['abundance']]
+        else:
+            self.abundance = abund 
 
     def _new_instance(self, temperature=None, **kwargs):
         """
@@ -94,7 +99,7 @@ Temperature range: [{self.temperature[0].to(u.MK):.3f}, {self.temperature[-1].to
 HDF5 Database: {self.hdf5_dbase_root}
 Using Datasets:
   ioneq: {self._dset_names['ioneq_filename']}
-  abundance: {self._dset_names['abundance_filename']}
+  abundance: {self._dset_names['abundance']}
   ip: {self._dset_names['ip_filename']}"""
 
     @cached_property
@@ -208,7 +213,11 @@ Using Datasets:
         """
         Elemental abundance relative to H.
         """
-        return self._abundance[self._dset_names['abundance_filename']]
+        return self._abundance
+        
+    @abundance.setter
+    def abundance(self, abundance):
+        self._abundance = abundance
 
     @property
     @needs_dataset('ip')

--- a/fiasco/ions.py
+++ b/fiasco/ions.py
@@ -131,10 +131,17 @@ Using Datasets:
         # Keyword arguments used to instantiate this Ion. These are useful when
         # constructing a new Ion instance that pulls from exactly the same
         # data sources.
-        kwargs = {
-            'hdf5_dbase_root': self.hdf5_dbase_root,
-            **self._dset_names,
-        }
+        if 'abundance' in self._dset_names.keys():
+            kwargs = {
+                'hdf5_dbase_root': self.hdf5_dbase_root,
+                **self._dset_names,
+            }
+        else:
+            kwargs = {
+                'hdf5_dbase_root': self.hdf5_dbase_root,
+                'abundance': self._abundance,
+                **self._dset_names,
+            }
         return kwargs
 
     def next_ion(self):

--- a/fiasco/ions.py
+++ b/fiasco/ions.py
@@ -43,7 +43,7 @@ class Ion(IonBase, ContinuumBase):
     ioneq_filename : `str`, optional
         Ionization equilibrium dataset
     abundance : `str` or `float`, optional
-        If a string is provided, use the appropriate abundance dataset.  
+        If a string is provided, use the appropriate abundance dataset.
         If a float is provided, use that value as the abundance.
     ip_filename : `str`, optional
         Ionization potential dataset
@@ -63,7 +63,7 @@ class Ion(IonBase, ContinuumBase):
             self._dset_names['abundance'] = abund
             self.abundance = self._abund[self._dset_names['abundance']]
         else:
-            self.abundance = abund 
+            self.abundance = abund
 
     def _new_instance(self, temperature=None, **kwargs):
         """
@@ -214,7 +214,7 @@ Using Datasets:
         Elemental abundance relative to H.
         """
         return self._abundance
-        
+
     @abundance.setter
     def abundance(self, abundance):
         self._abundance = abundance

--- a/fiasco/ions.py
+++ b/fiasco/ions.py
@@ -131,17 +131,16 @@ Using Datasets:
         # Keyword arguments used to instantiate this Ion. These are useful when
         # constructing a new Ion instance that pulls from exactly the same
         # data sources.
-        if 'abundance' in self._dset_names.keys():
-            kwargs = {
-                'hdf5_dbase_root': self.hdf5_dbase_root,
-                **self._dset_names,
-            }
-        else:
-            kwargs = {
-                'hdf5_dbase_root': self.hdf5_dbase_root,
-                'abundance': self._abundance,
-                **self._dset_names,
-            }
+        kwargs = {
+            'hdf5_dbase_root': self.hdf5_dbase_root,
+            **self._dset_names,
+        }
+        # If the abundance is set using a string specifying the abundance dataset,
+        # the dataset name is in _dset_names. We want to pass this to the new instance
+        # so that the new instance knows that the abundance was specified using a
+        # dataset name. Otherwise, we can just pass the actual abundance value.
+        if kwargs['abundance'] is None:
+            kwargs['abundance'] = self.abundance
         return kwargs
 
     def next_ion(self):
@@ -212,7 +211,8 @@ Using Datasets:
         return u.Quantity(ioneq)
 
     @property
-    def abundance(self):
+    @u.quantity_input
+    def abundance(self) -> u.dimensionless_unscaled:
         """
         Elemental abundance relative to H.
         """
@@ -229,6 +229,7 @@ Using Datasets:
             self._dset_names['abundance'] = abundance
             self._abundance = self._abund[self._dset_names['abundance']]
         else:
+            self._dset_names['abundance'] = None
             self._abundance = abundance
 
     @property

--- a/fiasco/tests/idl/test_idl_continuum.py
+++ b/fiasco/tests/idl/test_idl_continuum.py
@@ -17,7 +17,7 @@ def all_ions(hdf5_dbase_root):
     abundance_name = 'sun_coronal_1992_feldman_ext'
     ioneq_name = 'chianti'
     ion_kwargs = {
-        'abundance_filename': abundance_name,
+        'abundance': abundance_name,
         'ioneq_filename': ioneq_name,
         'hdf5_dbase_root': hdf5_dbase_root,
     }
@@ -35,7 +35,7 @@ def idl_input_args(all_ions, wavelength):
     return {
         'wavelength': wavelength,
         'temperature': all_ions.temperature,
-        'abundance': all_ions[0]._dset_names['abundance_filename'],
+        'abundance': all_ions[0]._dset_names['abundance'],
         'ioneq': all_ions[0]._dset_names['ioneq_filename'],
     }
 

--- a/fiasco/tests/idl/test_idl_goft.py
+++ b/fiasco/tests/idl/test_idl_goft.py
@@ -72,7 +72,7 @@ def test_idl_compare_goft(idl_env, hdf5_dbase_root, dbase_version, ion_name, wav
     ion = fiasco.Ion(ion_name,
                      idl_result['temperature'],
                      hdf5_dbase_root=hdf5_dbase_root,
-                     abundance_filename=idl_result['abundance'],
+                     abundance=idl_result['abundance'],
                      ioneq_filename=idl_result['ioneq'])
     contribution_func = ion.contribution_function(idl_result['density'])
     idx = np.argmin(np.abs(ion.transitions.wavelength[~ion.transitions.is_twophoton] - idl_result['wavelength']))

--- a/fiasco/tests/test_element.py
+++ b/fiasco/tests/test_element.py
@@ -83,3 +83,14 @@ def test_equilibrium_ionization(hdf5_dbase_root):
 
 def test_element_repr(element):
     assert element.element_name in element.__repr__()
+
+
+@pytest.mark.parametrize(('value', 'dset'),[
+    (0.07943282347242822, 'sun_coronal_1992_feldman_ext'),
+    (0.08511380382023759, 'sun_photospheric_2007_grevesse'),
+    (1e-3, None),
+])
+def test_change_element_abundance(another_element, value, dset):
+    another_element.abundance = value if dset is None else dset
+    assert u.allclose(another_element.abundance, value)
+    assert u.allclose(another_element[1].abundance, value)

--- a/fiasco/tests/test_ion.py
+++ b/fiasco/tests/test_ion.py
@@ -157,10 +157,10 @@ def test_proton_collision(fe10):
 
 def test_missing_abundance(hdf5_dbase_root):
     with pytest.raises(KeyError):
-        ion = fiasco.Ion('Li 1',
-                        temperature,
-                        abundance='sun_coronal_1992_feldman',
-                        hdf5_dbase_root=hdf5_dbase_root)
+        fiasco.Ion('Li 1',
+                    temperature,
+                    abundance='sun_coronal_1992_feldman',
+                    hdf5_dbase_root=hdf5_dbase_root)
 
 
 def test_ip(ion):

--- a/fiasco/tests/test_ion.py
+++ b/fiasco/tests/test_ion.py
@@ -156,12 +156,11 @@ def test_proton_collision(fe10):
 
 
 def test_missing_abundance(hdf5_dbase_root):
-    ion = fiasco.Ion('Li 1',
-                     temperature,
-                     abundance='sun_coronal_1992_feldman',
-                     hdf5_dbase_root=hdf5_dbase_root)
     with pytest.raises(KeyError):
-        _ = ion.abundance
+        ion = fiasco.Ion('Li 1',
+                        temperature,
+                        abundance='sun_coronal_1992_feldman',
+                        hdf5_dbase_root=hdf5_dbase_root)
 
 
 def test_ip(ion):

--- a/fiasco/tests/test_ion.py
+++ b/fiasco/tests/test_ion.py
@@ -45,7 +45,7 @@ def fe20(hdf5_dbase_root):
 
 
 def test_new_instance(ion):
-    abundance_filename = ion._instance_kwargs['abundance_filename']
+    abundance_filename = ion._instance_kwargs['abundance']
     new_ion = ion._new_instance()
     for k in new_ion._instance_kwargs:
         assert new_ion._instance_kwargs[k] == ion._instance_kwargs[k]
@@ -53,8 +53,8 @@ def test_new_instance(ion):
     new_ion = ion._new_instance(temperature=ion.temperature[:1])
     assert u.allclose(new_ion.temperature, ion.temperature[:1])
     new_ion = ion._new_instance(abundance_filename='sun_coronal_1992_feldman')
-    assert new_ion._instance_kwargs['abundance_filename'] == 'sun_coronal_1992_feldman'
-    assert ion._instance_kwargs['abundance_filename'] == abundance_filename
+    assert new_ion._instance_kwargs['abundance'] == 'sun_coronal_1992_feldman'
+    assert ion._instance_kwargs['abundance'] == abundance_filename
 
 
 def test_level_indexing(ion):
@@ -158,7 +158,7 @@ def test_proton_collision(fe10):
 def test_missing_abundance(hdf5_dbase_root):
     ion = fiasco.Ion('Li 1',
                      temperature,
-                     abundance_filename='sun_coronal_1992_feldman',
+                     abundance='sun_coronal_1992_feldman',
                      hdf5_dbase_root=hdf5_dbase_root)
     with pytest.raises(KeyError):
         _ = ion.abundance

--- a/fiasco/tests/test_ion.py
+++ b/fiasco/tests/test_ion.py
@@ -45,16 +45,16 @@ def fe20(hdf5_dbase_root):
 
 
 def test_new_instance(ion):
-    abundance_filename = ion._instance_kwargs['abundance']
+    abundance = ion._instance_kwargs['abundance']
     new_ion = ion._new_instance()
     for k in new_ion._instance_kwargs:
         assert new_ion._instance_kwargs[k] == ion._instance_kwargs[k]
     assert u.allclose(new_ion.temperature, ion.temperature, rtol=0)
     new_ion = ion._new_instance(temperature=ion.temperature[:1])
     assert u.allclose(new_ion.temperature, ion.temperature[:1])
-    new_ion = ion._new_instance(abundance_filename='sun_coronal_1992_feldman')
+    new_ion = ion._new_instance(abundance='sun_coronal_1992_feldman')
     assert new_ion._instance_kwargs['abundance'] == 'sun_coronal_1992_feldman'
-    assert ion._instance_kwargs['abundance'] == abundance_filename
+    assert ion._instance_kwargs['abundance'] == abundance
 
 
 def test_level_indexing(ion):

--- a/fiasco/tests/test_ion.py
+++ b/fiasco/tests/test_ion.py
@@ -137,7 +137,7 @@ def test_ioneq_out_bounds_is_nan(ion):
     assert np.isnan(ion_out_of_bounds.ioneq).all()
 
 
-def test_formation_temeprature(ion):
+def test_formation_temperature(ion):
     assert ion.formation_temperature == ion.temperature[np.argmax(ion.ioneq)]
 
 
@@ -161,7 +161,6 @@ def test_missing_abundance(hdf5_dbase_root):
                     temperature,
                     abundance='sun_coronal_1992_feldman',
                     hdf5_dbase_root=hdf5_dbase_root)
-
 
 def test_ip(ion):
     assert ion.ip.dtype == np.dtype('float64')
@@ -388,3 +387,49 @@ def test_previous_ion(ion):
     prev_ion = ion.previous_ion()
     assert prev_ion.ionization_stage == ion.ionization_stage - 1
     assert prev_ion.atomic_number == ion.atomic_number
+
+
+def test_change_ion_abundance(ion):
+    assert ion._dset_names['abundance'] == 'sun_coronal_1992_feldman_ext'
+    assert ion._instance_kwargs['abundance'] == 'sun_coronal_1992_feldman_ext'
+    assert u.allclose(ion.abundance, 0.0001258925411794166)
+
+    ion.abundance = 'sun_photospheric_2007_grevesse'
+    assert ion._dset_names['abundance'] == 'sun_photospheric_2007_grevesse'
+    assert u.allclose(ion.abundance, 2.818382931264455e-05)
+
+    ion.abundance = 1e-3
+    assert u.allclose(ion.abundance, 1e-3)
+
+
+def test_change_element_abundance(hdf5_dbase_root):
+    element = fiasco.Element('iron',
+                             temperature,
+                             abundance='sun_coronal_1992_feldman_ext',
+                             hdf5_dbase_root=hdf5_dbase_root)
+    assert u.allclose(element.abundance, 0.0001258925411794166)
+    assert u.allclose(element[10].abundance, 0.0001258925411794166)
+
+    element.abundance = 1e-3
+    assert u.allclose(element.abundance, 1e-3)
+    assert u.allclose(element[10].abundance, 1e-3)
+
+    element2 = fiasco.Element('iron',
+                              temperature,
+                              abundance=1e-3,
+                              hdf5_dbase_root=hdf5_dbase_root)
+    assert u.allclose(element2.abundance, 1e-3)
+    assert u.allclose(element2[10].abundance, 1e-3)
+
+    element2.abundance = 'sun_photospheric_2007_grevesse'
+    assert u.allclose(element2.abundance, 2.818382931264455e-05)
+    assert u.allclose(element2[10].abundance, 2.818382931264455e-05)
+
+
+def test_new_instance_float_abundance(hdf5_dbase_root):
+    ion = fiasco.Ion('Fe 1',
+                     temperature,
+                     abundance=1e-3,
+                     hdf5_dbase_root=hdf5_dbase_root)
+    new_ion = ion._new_instance()
+    assert u.allclose(new_ion._instance_kwargs['abundance'], 1e-3)


### PR DESCRIPTION
Fixes #237 

This PR adds a setter for the `abundance` property on the `Ion` and `Element` objects such that a user can supply a custom value of the abundance when creating the object or set the `abundance` property after instantiation.

Please review, and check whether there's any additional logic worth adding.

Looks functional: 
```
(base) C:\Users\reep\Documents\Forks>python
Python 3.11.5 | packaged by conda-forge | (main, Aug 27 2023, 03:23:48) [MSC v.1936 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import astropy.units as u
>>> import fiasco
>>> iron = fiasco.Element('iron', [1e4, 1e6, 1e8]*u.K)
>>> iron.abundance
<Quantity 0.00012589>
>>> iron.abundance = 1e-3
>>> iron.abundance
0.001
>>> iron[26].abundance
0.001
>>> exit()

(base) C:\Users\reep\Documents\Forks>python
Python 3.11.5 | packaged by conda-forge | (main, Aug 27 2023, 03:23:48) [MSC v.1936 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import astropy.units as u
>>> import fiasco
>>> iron = fiasco.Element('iron', [1e4, 1e6, 1e8]*u.K, abundance=1e-3)
>>> iron.abundance
0.001
>>> iron[26].abundance
0.001
>>> exit()

(base) C:\Users\reep\Documents\Forks>python
Python 3.11.5 | packaged by conda-forge | (main, Aug 27 2023, 03:23:48) [MSC v.1936 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import astropy.units as u
>>> import fiasco
>>> iron = fiasco.Element('iron', [1e4, 1e6, 1e8]*u.K, abundance='sun_photospheric_2007_grevesse')
>>> iron.abundance
<Quantity 2.81838293e-05>
>>> iron[26].abundance
<Quantity 2.81838293e-05>
>>> iron.abundance = 1e-3
>>> iron[26].abundance
0.001
```