### PR TITLE
Add a `_has_dataset` method to `Ion`

### DIFF
--- a/fiasco/tests/test_ion.py
+++ b/fiasco/tests/test_ion.py
@@ -423,3 +423,10 @@ def test_new_instance_abundance_preserved_string(ion):
     new_ion = ion._new_instance()
     assert u.allclose(new_ion.abundance, 2.818382931264455e-05)
     assert new_ion._dset_names['abundance'] == 'sun_photospheric_2007_grevesse'
+
+
+def test_has_dataset(ion):
+    # Fe 5 has energy level data
+    assert ion._has_dataset('elvlc')
+    # Fe 5 has no proton data
+    assert not ion._has_dataset('psplups')

--- a/fiasco/tests/test_ion.py
+++ b/fiasco/tests/test_ion.py
@@ -425,8 +425,10 @@ def test_new_instance_abundance_preserved_string(ion):
     assert new_ion._dset_names['abundance'] == 'sun_photospheric_2007_grevesse'
 
 
-def test_has_dataset(ion):
+def test_has_dataset(ion, c6):
     # Fe 5 has energy level data
     assert ion._has_dataset('elvlc')
     # Fe 5 has no proton data
     assert not ion._has_dataset('psplups')
+    # C VI has no dielectronic data
+    assert not c6._has_dataset('dielectronic_elvlc')


### PR DESCRIPTION
Fixes #268 by adding a private method that can be easily used to check for the existence of a dataset on an `Ion`.