### PR TITLE
Ignore asdf-astropy warning about version mismatch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ filterwarnings =[
   # Can be removed when pandas 3.0.0 is released
   "ignore:\\nPyarrow will become a required dependency of pandas in the next major release of pandas:DeprecationWarning",
   # Files created with previous versions of asdf-astropy issue a warning if you have a different version installed
-  "ignore:File * was created with extension * which is not currently installed:asdf.exceptions.AsdfWarning",
+  "ignore::asdf.exceptions.AsdfWarning",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,8 @@ filterwarnings =[
   "ignore:The unit 'Angstrom' has been deprecated in the VOUnit standard.*:astropy.units.core.UnitsWarning",
   # Can be removed when pandas 3.0.0 is released
   "ignore:\\nPyarrow will become a required dependency of pandas in the next major release of pandas:DeprecationWarning",
+  # Files created with previous versions of asdf-astropy issue a warning if you have a different version installed
+  "ignore:File * was created with extension * which is not currently installed:asdf.exceptions.AsdfWarning",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
The IDL results files were produced with `asdf-astropy==0.5.0`. The current version is 0.6.0. A warning is being raised when reading these files in that causes the tests to fail. This adds an ignore for that warning. If there is some other way to suppress this or if this turns out to be a bug, this ignore can be removed.