### PR TITLE
Add graphviz as an apt dependency for the readthedocs build.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "mambaforge-4.10"
+  apt_packages:
+    - graphviz
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
The [Code Reference page](https://fiasco.readthedocs.io/en/stable/code_ref/fiasco.html) has a broken class inheritance diagram.

This PR adds graphviz as an apt dependency to the readthedocs build to attempt to render that diagram correctly.

Apologies if this has already been fixed and I'm just late to the party.