### PR TITLE
Add isoelectronic sequence property and helper function

### DIFF
--- a/fiasco/__init__.py
+++ b/fiasco/__init__.py
@@ -3,7 +3,12 @@ fiasco: A Python interface to the CHIANTI atomic database
 """
 from fiasco.collections import IonCollection
 from fiasco.elements import Element
-from fiasco.fiasco import list_elements, list_ions, proton_electron_ratio
+from fiasco.fiasco import (
+    get_isoelectronic_sequence,
+    list_elements,
+    list_ions,
+    proton_electron_ratio,
+)
 from fiasco.gaunt import GauntFactor
 from fiasco.ions import Ion
 from fiasco.levels import Level, Transitions

--- a/fiasco/base.py
+++ b/fiasco/base.py
@@ -72,6 +72,10 @@ class Base:
         return self.ionization_stage - 1
 
     @property
+    def isoelectronic_sequence(self):
+        return plasmapy.particles.atomic_symbol(self.atomic_number - self.charge_state)
+
+    @property
     def _ion_name(self):
         # Old CHIANTI format, only preserved for internal data access
         return f'{self.atomic_symbol.lower()}_{self.ionization_stage}'

--- a/fiasco/ions.py
+++ b/fiasco/ions.py
@@ -262,7 +262,7 @@ Using Datasets:
         -----
         This is `True` if :math:`Z - z = 1`.
         """
-        return (self.atomic_number - self.charge_state == 1)
+        return self.isoelectronic_sequence == 'H'
 
     @property
     def helium_like(self):
@@ -273,7 +273,7 @@ Using Datasets:
         -----
         This is `True` if :math:`Z - z = 2`.
         """
-        return (self.atomic_number - self.charge_state == 2)
+        return self.isoelectronic_sequence == 'He'
 
     @property
     @u.quantity_input

--- a/fiasco/ions.py
+++ b/fiasco/ions.py
@@ -88,6 +88,7 @@ class Ion(IonBase, ContinuumBase):
 Name: {self.ion_name}
 Element: {self.element_name} ({self.atomic_number})
 Charge: +{self.charge_state}
+Isoelectronic Sequence: {self.isoelectronic_sequence}
 Number of Levels: {n_levels}
 Number of Transitions: {n_transitions}
 

--- a/fiasco/tests/test_base.py
+++ b/fiasco/tests/test_base.py
@@ -25,6 +25,7 @@ def test_create_ion_input_formats(hdf5_dbase_root, ion_name):
     assert ion.atomic_number == 26
     assert ion.ionization_stage == 21
     assert ion.charge_state == 20
+    assert ion.isoelectronic_sequence == 'C'
     assert ion._ion_name == 'fe_21'
     assert ion.ion_name_roman == 'Fe XXI'
     assert ion.ionization_stage_roman == 'XXI'

--- a/fiasco/tests/test_fiasco.py
+++ b/fiasco/tests/test_fiasco.py
@@ -19,6 +19,15 @@ def test_list_ions(hdf5_dbase_root):
     assert isinstance(ions, list)
 
 
+def test_get_isoelectronic_sequence(hdf5_dbase_root):
+    iso_seq = fiasco.get_isoelectronic_sequence('iron')
+    assert iso_seq == ['Fe 1',
+                       'Co 2',
+                       'Ni 3',
+                       'Cu 4',
+                       'Zn 5',]
+
+
 def test_proton_electron_ratio(hdf5_dbase_root):
     t = np.logspace(4, 9, 100) * u.K
     # NOTE: this number will not be accurate as we are using only a subset of

--- a/fiasco/tests/test_fiasco.py
+++ b/fiasco/tests/test_fiasco.py
@@ -20,7 +20,8 @@ def test_list_ions(hdf5_dbase_root):
 
 
 def test_get_isoelectronic_sequence(hdf5_dbase_root):
-    iso_seq = fiasco.get_isoelectronic_sequence('iron')
+    iso_seq = fiasco.get_isoelectronic_sequence('iron',
+                                                hdf5_dbase_root=hdf5_dbase_root)
     assert iso_seq == ['Fe 1',
                        'Co 2',
                        'Ni 3',


### PR DESCRIPTION
Ions in the same isoelectronic sequence (i.e. those that have the same number of bound electrons) often share common properties despite having different charge states and being from different ions. As such, it is often useful to know to which isoelectronic sequence an ion belongs or to group ions of a single sequence together.

As such, this PR adds two features:

- Add a `isoelectronic_sequence` property to `fiasco.Ion`
- Add a helper function `fiasco.get_isoelectronic_sequence` that returns all ions in CHIANTI that fall within a given isoelectronic sequence.