### PR TITLE
Tidy up docstrings, add `Level.is_observed` property

### DIFF
--- a/docs/reference/code_ref/fiasco.rst
+++ b/docs/reference/code_ref/fiasco.rst
@@ -1,1 +1,2 @@
 .. automodapi:: fiasco
+    :inherited-members:

--- a/fiasco/__init__.py
+++ b/fiasco/__init__.py
@@ -53,6 +53,7 @@ __all__ = [
     "Element",
     "list_elements",
     "list_ions",
+    "get_isoelectronic_sequence",
     "proton_electron_ratio",
     "Ion",
     "Level",

--- a/fiasco/base.py
+++ b/fiasco/base.py
@@ -49,30 +49,37 @@ class Base:
 
     @property
     def atomic_number(self):
+        """The atomic number of the element, :math:`Z`."""
         return plasmapy.particles.atomic_number(self._base_rep[0])
 
     @property
     def element_name(self):
+        """The full name of the element, e.g. "hydrogen"."""
         return plasmapy.particles.element_name(self.atomic_number)
 
     @property
     def atomic_symbol(self):
+        """The standard atomic symbol for the element, e.g. "H" for hydrogen."""
         return plasmapy.particles.atomic_symbol(self.atomic_number)
 
     @property
     def ion_name(self):
+        """The name of the element and ionization stage, e.g. "Fe 11"."""
         return f'{self.atomic_symbol} {self.ionization_stage}'
 
     @property
     def ionization_stage(self):
+        """Number denoting the degree of ionization, with 1 denoting the neutral stage."""
         return self._base_rep[1]
 
     @property
     def charge_state(self):
+        "Total number of electrons removed, :math:`z`."
         return self.ionization_stage - 1
 
     @property
     def isoelectronic_sequence(self):
+        "Atomic symbol denoting to which isoelectronic sequence this ion belongs."
         return plasmapy.particles.atomic_symbol(self.atomic_number - self.charge_state)
 
     @property
@@ -82,10 +89,12 @@ class Base:
 
     @property
     def ionization_stage_roman(self):
+        "Ionization stage in roman numeral format."
         return roman.to_roman(int(self.ionization_stage))
 
     @property
     def ion_name_roman(self):
+        "Name of the element and ionization stage in roman numeral format."
         return f'{self.atomic_symbol} {self.ionization_stage_roman}'
 
 

--- a/fiasco/collections.py
+++ b/fiasco/collections.py
@@ -17,8 +17,16 @@ __all__ = ['IonCollection']
 
 class IonCollection:
     """
-    Container for holding multiple ions.
-    Instantiate with ions, elements, or another ion collection.
+    Container for holding multiple `~fiasco.Ion` instances.
+
+    This container is most useful when needing to group many ions together in
+    order to perform some aggregate calculation like a radiative loss curve or
+    a composite spectrum made up of ions from many different elements.
+
+    Parameters
+    ----------
+    *ions: `fiasco.Ion` or `fiasco.IonCollection`
+        Entries can be either ions or collections of ion.
     """
 
     def __init__(self, *args):
@@ -212,8 +220,8 @@ Available Ions
         """
         Calculate spectrum for multiple ions
 
-        .. note:: This function is still experimental and may be removed or significantly
-                  refactored in future releases.
+        .. warning:: This function is still experimental and may be removed or significantly
+                     refactored in future releases.
 
         Parameters
         ----------

--- a/fiasco/elements.py
+++ b/fiasco/elements.py
@@ -47,18 +47,22 @@ class Element(fiasco.IonCollection):
 
     @property
     def atomic_symbol(self):
+        """The standard atomic symbol for the element, e.g. "H" for hydrogen."""
         return self[0].atomic_symbol
 
     @property
     def atomic_number(self):
+        """The atomic number of the element, :math:`Z`."""
         return self[0].atomic_number
 
     @property
     def element_name(self):
+        """The full name of the element, e.g. "hydrogen"."""
         return self[0].element_name
 
     @property
     def abundance(self):
+        "Elemental abundance relative to H."
         return self[0].abundance
 
     @abundance.setter
@@ -85,12 +89,18 @@ class Element(fiasco.IonCollection):
     @cached_property
     def equilibrium_ionization(self):
         """
-        Calculate the ionization fraction, in equilibrium, for all ions of the element.
+        The ionization fraction, in equilibrium, for all ions of the element.
 
-        Calculate the population fractions for every ion of this element as a function of
-        temperature, assuming ionization equilibrium. This returns a matrix with dimensions
-        ``(n,Z+1)``, where ``n`` corresponds to the temperature dimension and ``Z+1``
-        corresponds to the number of ionization stages of the element.
+        The population fractions for every ion of this element, assuming
+        ionization equilibrium, calculated as a function of temperature.
+        This returns a matrix with dimensions ``(n,Z+1)``, where ``n``
+        corresponds to the temperature dimension and ``Z+1`` corresponds to
+        the number of ionization stages of the element.
+
+        .. note:: The result here is not simply the tabulated values included in
+                  the CHIANTI database. Rather, these values are calculated as a
+                  function of temperature on the fly using the ionization and
+                  recombination rates associated with each ion in the element.
 
         Examples
         --------

--- a/fiasco/fiasco.py
+++ b/fiasco/fiasco.py
@@ -80,7 +80,16 @@ def list_ions(hdf5_dbase_root=None, sort=True):
 
 def get_isoelectronic_sequence(element, hdf5_dbase_root=None):
     """
-    Return a list of ions in the isoelectronic sequence of ``element``.
+    List of ions in the isoelectronic sequence of ``element``.
+
+    Ions in the same isoelectronic sequence, that is, ions that have the
+    same number of bound electrons, :math:`Z - z`, often share common properties
+    despite having different charge states and being from different elements.
+    These so-called isoelectronic sequences are typically denoted by the element
+    with an atomic number equal to the number of bound electrons, e.g. C II is in
+    the boron isoelectronic sequence or equivalently may be said to be boron-like.
+    Given the name of a sequence, as denoted by an element label, this function
+    returns a list of all ions in that sequence.
 
     Parameters
     ----------

--- a/fiasco/levels.py
+++ b/fiasco/levels.py
@@ -65,7 +65,7 @@ Energy: {self.energy.to(u.eV)}"""
     @property
     def is_observed(self) -> u.erg:
         "True if the energy of the level is from laboratory measurements."
-        return self._elvlc['E_obs'][self._index] != -1
+        return self._elvlc['E_obs'][self._index].to_value('cm-1') != -1
 
     @property
     @u.quantity_input
@@ -74,9 +74,9 @@ Energy: {self.energy.to(u.eV)}"""
         Energy of level. Defaults to observed energy and falls back to
         theoretical energy if no measured energy is available.
         """
-        if (E_obs := self._elvlc['E_obs'][self._index]) != -1:
-            return E_obs * const.h * const.c
-        return self._elvlc['E_th'][self._index] * const.h * const.c
+        if self.is_observed:
+            return self._elvlc['E_obs'][self._index].to('erg', equivalencies=u.equivalencies.spectral())
+        return self._elvlc['E_th'][self._index].to('erg', equivalencies=u.equivalencies.spectral())
 
 
 class Transitions:

--- a/fiasco/tests/test_ion.py
+++ b/fiasco/tests/test_ion.py
@@ -98,6 +98,16 @@ def test_level(ion):
     assert level.orbital_angular_momentum_label == 'D'
 
 
+def test_level_energy_parsing(fe10):
+    # Test falling back to theoretical energies if energies are not observed
+    for i, level in enumerate(fe10):
+        if level.is_observed:
+            assert level.energy == fe10._elvlc['E_obs'][i].to('erg', equivalencies=u.spectral())
+        else:
+            assert fe10._elvlc['E_obs'][i].to_value('cm-1') == -1
+            assert level.energy == fe10._elvlc['E_th'][i].to('erg', equivalencies=u.spectral())
+
+
 def test_repr(ion):
     assert 'Fe 5' in ion.__repr__()
 


### PR DESCRIPTION
This PR actually renders the docstring of the function added in #320 and also tidies up docstrings all over the package, many of which have been missing for a long time.

The only feature this adds is the property `Level.is_observed` to denote whether the energy of a level is taken from laboratory measurements or theoretical calculations.