### PR TITLE
Error explicitly when Itoh data is missing in free-free collection calculation

### DIFF
--- a/fiasco/collections.py
+++ b/fiasco/collections.py
@@ -115,8 +115,8 @@ Available Ions
         free_free = u.Quantity(np.zeros(self.temperature.shape + wavelength.shape),
                                'erg cm^3 s^-1 Angstrom^-1')
         for ion in self:
+            ff = ion.free_free(wavelength)
             try:
-                ff = ion.free_free(wavelength)
                 abundance = ion.abundance
                 ioneq = ion.ioneq
             except MissingDatasetException as e:

--- a/fiasco/gaunt.py
+++ b/fiasco/gaunt.py
@@ -124,15 +124,14 @@ HDF5 Database: {self.hdf5_dbase_root}"""
         lower_u = const.h * const.c / const.k_B / tmp
         upper_u = 1. / 2.5 * (np.log10(lower_u) + 1.5)
         t = 1. / 1.25 * (log10_temperature - 7.25)
-        itoh_coefficients = self._itoh['a'][atomic_number-1]
+        itoh_coefficients = self._itoh['a'][self._itoh['Z']==atomic_number].squeeze()
         # calculate Gaunt factor
         gf = u.Quantity(np.zeros(upper_u.shape))
-        for j in range(11):
-            for i in range(11):
+        for i in range(itoh_coefficients.shape[0]):
+            for j in range(itoh_coefficients.shape[1]):
                 gf += (itoh_coefficients[i, j] * (t**i))[:, np.newaxis] * (upper_u**j)
         # apply NaNs where Itoh approximation is not valid
-        gf = np.where(np.logical_and(np.log10(lower_u) >= -4., np.log10(lower_u) <= 1.0),
-                      gf, np.nan)
+        gf = np.where(np.logical_and(np.log10(lower_u) >= -4., np.log10(lower_u) <= 1.0), gf, np.nan)
         gf[np.where(np.logical_or(log10_temperature <= 6.0, log10_temperature >= 8.5)), :] = np.nan
         return gf
 


### PR DESCRIPTION
Fixes #328 

This should force an exception to be thrown when computing the free-free emission when using an older version of the database. It also makes a small fix to make the selection of the Itoh coefficients more robust.

I decided not to add an exception that explicitly pointed out the need to update the database because it just felt clunky.