### PR TITLE
Use `memmap=False` instead of `copy_arrays=False` when opening `asdf` files

### DIFF
--- a/fiasco/tests/idl/helpers.py
+++ b/fiasco/tests/idl/helpers.py
@@ -21,10 +21,8 @@ def get_idl_test_output_filepath(name, version):
 
 
 def read_idl_test_output(name, version, keys=None):
-    # NOTE: Importing here to avoid it as a hard dependency for running tests
-    import asdf
     file_path = get_idl_test_output_filepath(name, version)
-    with asdf.open(file_path, copy_arrays=True) as af:
+    with asdf.open(file_path, memmap=True) as af:
         if keys is None:
             keys = af.tree.keys()
         output = {k: af.tree[k] for k in keys}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ all = ["fiasco"]
 test = [
   "fiasco[all]",
   "asdf-astropy",
-  "asdf",
+  "asdf>=3.1",
   "matplotlib",
   "pytest-astropy",
   "pytest-cov",
@@ -69,7 +69,7 @@ docs =[
   "fiasco[all]",
   "aiapy",
   "asdf-astropy",
-  "asdf",
+  "asdf>=3.1",
   "hissw",
   "pydata-sphinx-theme",
   "sphinx-automodapi",


### PR DESCRIPTION
Fixes #338 