### PR TITLE
Rename `ip` property and fix setter logic for abundance, ionization potential, and ionization fraction.

### DIFF
--- a/fiasco/base.py
+++ b/fiasco/base.py
@@ -147,6 +147,11 @@ class IonBase(Base):
         data_path = '/'.join([self.atomic_symbol.lower(), self._ion_name, 'ioneq'])
         return DataIndexer.create_indexer(self.hdf5_dbase_root, data_path)
 
+    @property
+    def _ip(self):
+        data_path = '/'.join([self.atomic_symbol.lower(), self._ion_name, 'ip'])
+        return DataIndexer.create_indexer(self.hdf5_dbase_root, data_path)
+
 
 def add_property(cls, filetype):
     """
@@ -166,4 +171,3 @@ all_ext = [cls.filetype for cls in all_subclasses(GenericIonParser) if hasattr(c
 for filetype in all_ext:
     add_property(IonBase, filetype)
     add_property(IonBase, '/'.join(['dielectronic', filetype]))
-add_property(IonBase, 'ip')

--- a/fiasco/io/datalayer.py
+++ b/fiasco/io/datalayer.py
@@ -124,6 +124,12 @@ class DataIndexerHDF5:
                     data = data.astype(str)
         return data
 
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
     def __repr__(self):
 
         def ufilter(x):

--- a/fiasco/tests/idl/test_idl_ioneq.py
+++ b/fiasco/tests/idl/test_idl_ioneq.py
@@ -25,17 +25,17 @@ from fiasco.util import parse_ion_name
 def test_ionization_fraction_from_idl(ion_name, idl_env, dbase_version, hdf5_dbase_root):
     Z, iz = parse_ion_name(ion_name)
     script = """
-    ioneq_file = FILEPATH('{{ionization_fraction}}.ioneq', ROOT_DIR=!xuvtop, SUBDIR='ioneq')
+    ioneq_file = FILEPATH('{{ioneq_filename}}.ioneq', ROOT_DIR=!xuvtop, SUBDIR='ioneq')
     read_ioneq, ioneq_file, temperature, ioneq, ioneq_ref
     ioneq = ioneq[*,{{Z-1}},{{iz-1}}]
     """
     formatters = {'temperature': lambda x: 10**x*u.K,
-                  'ionization_fraction': lambda x: x*u.dimensionless_unscaled}
+                  'ioneq': lambda x: x*u.dimensionless_unscaled}
     idl_result = run_idl_script(idl_env,
                                 script,
-                                {'ionization_fraction': 'chianti', 'Z': Z, 'iz': iz},
-                                ['temperature', 'ionization_fraction'],
-                                f'ionization_{Z}_{iz}',
+                                {'ioneq_filename': 'chianti', 'Z': Z, 'iz': iz},
+                                ['temperature', 'ioneq'],
+                                f'ioneq_{Z}_{iz}',
                                 dbase_version,
                                 format_func=formatters)
     ion = fiasco.Ion(ion_name,

--- a/fiasco/tests/test_gaunt.py
+++ b/fiasco/tests/test_gaunt.py
@@ -78,7 +78,12 @@ def test_gaunt_factor_free_bound_nl_missing(gaunt_factor):
 
 @pytest.mark.parametrize(('ground_state', 'expected'), [(True, 55.18573076316151), (False, 11.849092513590998)])
 def test_gaunt_factor_free_bound_integrated(ion, ground_state, expected):
-    gf = ion.gaunt_factor.free_bound_integrated(ion.temperature, ion.atomic_number, ion.charge_state, ion.previous_ion()._fblvl['n'][0], ion.previous_ion().ip, ground_state=ground_state)
+    gf = ion.gaunt_factor.free_bound_integrated(ion.temperature,
+                                                ion.atomic_number,
+                                                ion.charge_state,
+                                                ion.previous_ion()._fblvl['n'][0],
+                                                ion.previous_ion().ionization_potential,
+                                                ground_state=ground_state)
     assert gf.shape == ion.temperature.shape
     # These values have not been tested for correctness
     assert u.isclose(gf[20], expected * u.dimensionless_unscaled)
@@ -91,5 +96,10 @@ def test_free_bound_gaunt_factor_low_temperature(gs, hdf5_dbase_root):
     # At low temperatures (~1e4 K), exponential terms in the gaunt factor used to compute the
     # free-bound radiative loss can blow up. This just tests to make sure those are handled correctly
     ion = fiasco.Ion('N 8', np.logspace(4,6,100)*u.K, hdf5_dbase_root=hdf5_dbase_root)
-    gf_fb_int = ion.gaunt_factor.free_bound_integrated(ion.temperature, ion.atomic_number, ion.charge_state, ion.previous_ion()._fblvl['n'][0], ion.previous_ion().ip, ground_state=gs)
+    gf_fb_int = ion.gaunt_factor.free_bound_integrated(ion.temperature,
+                                                       ion.atomic_number,
+                                                       ion.charge_state,
+                                                       ion.previous_ion()._fblvl['n'][0],
+                                                       ion.previous_ion().ionization_potential,
+                                                       ground_state=gs)
     assert not np.isinf(gf_fb_int).any()

--- a/fiasco/util/decorators.py
+++ b/fiasco/util/decorators.py
@@ -12,8 +12,7 @@ def needs_dataset(*names):
     """
     Decorator for raising an error when the needed atomic data is not available.
     """
-    non_ion_datasets = ['abundance', 'ionization_fraction']
-    names = [f'_{n}' if n not in non_ion_datasets else f'{n}' for n in names]
+    names = [f'_{n}' for n in names]
 
     def decorator(func):
         """


### PR DESCRIPTION
Fixes #325
Fixes #323 
Fixes #341 

In addition, this PR also simplifies and standardizes some of the logic for the setters for `abundance` and `ionization_potential`. 