### PR TITLE
Set isoelectronic sequence to None when Z==charge_state

### DIFF
--- a/fiasco/base.py
+++ b/fiasco/base.py
@@ -83,7 +83,8 @@ class IonBase:
     @property
     def isoelectronic_sequence(self):
         "Atomic symbol denoting to which isoelectronic sequence this ion belongs."
-        return plasmapy.particles.atomic_symbol(self.atomic_number - self.charge_state)
+        if (Z_iso := self.atomic_number - self.charge_state) > 0:
+            return plasmapy.particles.atomic_symbol(Z_iso)
 
     @property
     def _ion_name(self):

--- a/fiasco/tests/test_base.py
+++ b/fiasco/tests/test_base.py
@@ -34,3 +34,14 @@ def test_create_ion_input_formats(hdf5_dbase_root, ion_name):
 def test_create_invalid_ion_raises_missing_ion_error(hdf5_dbase_root):
     with pytest.raises(MissingIonError):
         fiasco.base.IonBase('hydrogen 3', hdf5_dbase_root=hdf5_dbase_root)
+
+
+@pytest.mark.parametrize(('ion_name', 'sequence_name'), [
+    ("Fe 21", "C"),
+    ("Fe 26", "H"),
+    ("Fe 25", "He"),
+    ("C 7", None),
+])
+def test_isoelectronic_sequence(ion_name, sequence_name):
+    ion = fiasco.base.IonBase(ion_name)
+    assert ion.isoelectronic_sequence == sequence_name

--- a/fiasco/tests/test_base.py
+++ b/fiasco/tests/test_base.py
@@ -42,6 +42,6 @@ def test_create_invalid_ion_raises_missing_ion_error(hdf5_dbase_root):
     ("Fe 25", "He"),
     ("C 7", None),
 ])
-def test_isoelectronic_sequence(ion_name, sequence_name):
-    ion = fiasco.base.IonBase(ion_name)
+def test_isoelectronic_sequence(ion_name, sequence_name, hdf5_dbase_root):
+    ion = fiasco.base.IonBase(ion_name, hdf5_dbase_root=hdf5_dbase_root)
     assert ion.isoelectronic_sequence == sequence_name


### PR DESCRIPTION
This fixes a bug where the isoelectronic sequence would try to be determined even in the case of a fully-ionized ion. An exception was being thrown by `plasmapy` because there is no Z=0 elemnt. These ions do not belong to an isoelectronic sequence so None is returned.