### PR TITLE
Disable two-ion model until solver issues are worked out

### DIFF
--- a/fiasco/ions.py
+++ b/fiasco/ions.py
@@ -526,7 +526,7 @@ Using Datasets:
                           include_protons=True,
                           include_level_resolved_rate_correction=True,
                           couple_density_to_temperature=False,
-                          use_two_ion_model=True) -> u.dimensionless_unscaled:
+                          use_two_ion_model=False) -> u.dimensionless_unscaled:
         """
         Energy level populations as a function of temperature and density.
 

--- a/fiasco/tests/idl/test_idl_goft.py
+++ b/fiasco/tests/idl/test_idl_goft.py
@@ -42,7 +42,8 @@ INDEX_WAVE_MAPPING = {
     ('Fe IX', 188.496*u.Angstrom),
     ('Fe XI', 188.497*u.Angstrom),
     ('Fe XIV', 197.862*u.Angstrom),
-    ('Fe XVI', 262.984*u.Angstrom),
+    pytest.param('Fe XVI', 262.984*u.Angstrom,
+                 marks=pytest.mark.skip(reason='Unskip once two-ion model is enabled by default')),
 ])
 def test_idl_compare_goft(idl_env, hdf5_dbase_root, dbase_version, chianti_idl_version, ion_name, wavelength):
     goft_script = """


### PR DESCRIPTION
This disables the two-ion model in the level populations function by default as the results are not reliable until #356 has been worked out. Once that is done, this can be reset to `True` by default.