### PR TITLE
Update citation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![fiasco CI status](https://github.com/wtbarnes/fiasco/actions/workflows/ci.yml/badge.svg)](https://github.com/wtbarnes/fiasco/actions/workflows/ci.yml)
 [![Documentation Status](https://readthedocs.org/projects/fiasco/badge/?version=stable)](https://fiasco.readthedocs.io/en/stable/?badge=stable)
 [![PyPI](https://img.shields.io/pypi/v/fiasco.svg)](https://pypi.python.org/pypi)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7504785.svg)](https://doi.org/10.5281/zenodo.7504785)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14757042.svg)](https://doi.org/10.5281/zenodo.14757042)
 [![codecov](https://codecov.io/gh/wtbarnes/fiasco/branch/main/graph/badge.svg?token=damCmTyRUN)](https://codecov.io/gh/wtbarnes/fiasco)
 [![matrix](https://img.shields.io/matrix/atomic-data:openastronomy.org.svg?colorB=%23FE7900&label=Chat&logo=matrix&server_fqdn=openastronomy.modular.im)](https://openastronomy.element.io/#/room/#atomic-data:openastronomy.org)
 

--- a/fiasco/CITATION.rst
+++ b/fiasco/CITATION.rst
@@ -9,7 +9,7 @@ Please add the following line within your methods, conclusion or acknowledgement
 *This research used version X.Y.Z (software citation) of the fiasco open source software package.*
 
 The software citation should be the specific `Zenodo DOI`_ for the version used within your work.
-The citation for most current version on Zenodo is,
+The citation for the most current version on Zenodo is,
 
 .. code:: bibtex
 

--- a/fiasco/CITATION.rst
+++ b/fiasco/CITATION.rst
@@ -13,20 +13,21 @@ The citation for most current version on Zenodo is,
 
 .. code:: bibtex
 
-   @software{Barnes2024,
+   @software{Barnes2025,
       author       = {Will Barnes and
                       David Stansby and
                       Nick Murphy and
                       Jeffrey Reep and
                       Laura Hayes and
-                      Stuart Mumford},
-      title        = {wtbarnes/fiasco: v0.2.3},
-      month        = feb,
-      year         = 2024,
+                      Stuart Mumford and
+                      Nabil Freij},
+      title        = {wtbarnes/fiasco: v0.4.0},
+      month        = jan,
+      year         = 2025,
       publisher    = {Zenodo},
-      version      = {v0.2.3},
-      doi          = {10.5281/zenodo.10612118},
-      url          = {https://doi.org/10.5281/zenodo.10612118}
+      version      = {v0.4.0},
+      doi          = {10.5281/zenodo.14757042},
+      url          = {https://doi.org/10.5281/zenodo.14757042}
    }
 
 You can also obtain this information with ``fiasco.__citation__``.
@@ -34,4 +35,4 @@ You can also obtain this information with ``fiasco.__citation__``.
 In addition to citing ``fiasco``, you should also cite the CHIANTI atomic database according to the
 `instructions here <https://www.chiantidatabase.org/referencing.html>`__.
 
-.. _Zenodo DOI: https://zenodo.org/records/10612118
+.. _Zenodo DOI: https://doi.org/10.5281/zenodo.7504257


### PR DESCRIPTION
The citation info was pointing to an older version.  This updates to the current version, and changes the Zenodo DOI link to the permanent one (for all versions).