### PR TITLE
Add mass property to Ions and Elements

### DIFF
--- a/fiasco/elements.py
+++ b/fiasco/elements.py
@@ -61,9 +61,10 @@ class Element(fiasco.IonCollection):
         return self[0].element_name
 
     @property
+    @u.quantity_input
     def mass(self) -> u.g:
         """The atomic mass of the element."""
-        return plasmapy.particles.Particle(self[0].element_name).mass.to(u.g)
+        return plasmapy.particles.Particle(self[0].element_name).mass
 
     @property
     def abundance(self):

--- a/fiasco/elements.py
+++ b/fiasco/elements.py
@@ -64,7 +64,7 @@ class Element(fiasco.IonCollection):
     @u.quantity_input
     def mass(self) -> u.g:
         """The atomic mass of the element."""
-        return plasmapy.particles.Particle(self[0].element_name).mass
+        return plasmapy.particles.Particle(self.element_name).mass
 
     @property
     def abundance(self):

--- a/fiasco/elements.py
+++ b/fiasco/elements.py
@@ -61,6 +61,11 @@ class Element(fiasco.IonCollection):
         return self[0].element_name
 
     @property
+    def mass(self) -> u.g:
+        """The atomic mass of the element."""
+        return plasmapy.particles.Particle(self[0].element_name).mass.to(u.g)
+
+    @property
     def abundance(self):
         "Elemental abundance relative to H."
         return self[0].abundance

--- a/fiasco/ions.py
+++ b/fiasco/ions.py
@@ -362,11 +362,12 @@ Using Datasets:
         return self.isoelectronic_sequence == 'He'
 
     @property
+    @u.quantity_input
     def mass(self) -> u.g:
         """
         Returns the atomic mass
         """
-        return plasmapy.particles.Particle(self.ion_name_roman).mass.to(u.g)
+        return plasmapy.particles.Particle(self.ion_name_roman).mass
 
     @property
     @u.quantity_input

--- a/fiasco/ions.py
+++ b/fiasco/ions.py
@@ -4,6 +4,7 @@ Ion object. Holds all methods and properties of a CHIANTI ion.
 import astropy.constants as const
 import astropy.units as u
 import numpy as np
+import plasmapy
 
 from functools import cached_property
 from scipy.interpolate import CubicSpline, interp1d, PchipInterpolator
@@ -359,6 +360,13 @@ Using Datasets:
         Is the ion in the helium isoelectronic sequence.
         """
         return self.isoelectronic_sequence == 'He'
+
+    @property
+    def mass(self) -> u.g:
+        """
+        Returns the atomic mass
+        """
+        return plasmapy.particles.Particle(self.ion_name_roman).mass.to(u.g)
 
     @property
     @u.quantity_input

--- a/fiasco/ions.py
+++ b/fiasco/ions.py
@@ -364,9 +364,7 @@ Using Datasets:
     @property
     @u.quantity_input
     def mass(self) -> u.g:
-        """
-        Returns the atomic mass
-        """
+        """Atomic mass of the ion."""
         return plasmapy.particles.Particle(self.ion_name_roman).mass
 
     @property

--- a/fiasco/tests/test_element.py
+++ b/fiasco/tests/test_element.py
@@ -96,6 +96,6 @@ def test_change_element_abundance(another_element, value, dset):
     assert u.allclose(another_element[1].abundance, value)
 
 def test_element_mass(element, another_element):
-    assert element.mass.unit == u.g
+    assert element.mass.unit.physical_type == 'mass'
     assert u.isclose(element.mass, 1.67382338e-24*u.g)
     assert u.isclose(another_element.mass, 6.64647699e-24*u.g)

--- a/fiasco/tests/test_element.py
+++ b/fiasco/tests/test_element.py
@@ -94,3 +94,8 @@ def test_change_element_abundance(another_element, value, dset):
     another_element.abundance = value if dset is None else dset
     assert u.allclose(another_element.abundance, value)
     assert u.allclose(another_element[1].abundance, value)
+
+def test_element_mass(element, another_element):
+    assert element.mass.unit == u.g
+    assert u.isclose(element.mass, 1.67382338e-24*u.g)
+    assert u.isclose(another_element.mass, 6.64647699e-24*u.g)

--- a/fiasco/tests/test_ion.py
+++ b/fiasco/tests/test_ion.py
@@ -557,6 +557,6 @@ def test_ionization_potential_setter(ion, ip_input, ip_output):
         )
 
 def test_ion_mass(fe10, c5):
-    assert fe10.mass.unit == u.g
+    assert fe10.mass.unit.physical_type == 'mass'
     assert u.isclose(fe10.mass, 9.27246057e-23*u.g)
     assert u.isclose(c5.mass, 1.9941091e-23*u.g)

--- a/fiasco/tests/test_ion.py
+++ b/fiasco/tests/test_ion.py
@@ -555,3 +555,8 @@ def test_ionization_potential_setter(ion, ip_input, ip_output):
             ion._instance_kwargs['ionization_potential'],
             ip_input.to('eV', equivalencies=u.equivalencies.spectral()),
         )
+
+def test_ion_mass(fe10, c5):
+    assert fe10.mass.unit == u.g
+    assert u.isclose(fe10.mass, 9.27246057e-23*u.g)
+    assert u.isclose(c5.mass, 1.9941091e-23*u.g)


### PR DESCRIPTION
Fixes #363 

This uses plasmapy to do the heavy lifting.  They already have the masses for both elements and individual ions, but this makes the mass readily accessible in fiasco.

I put the units in grams, but it's trivial to switch to amu if preferred.