### PR TITLE
Fix abundance parsing for v11

### DIFF
--- a/fiasco/io/sources/non_ion_sources.py
+++ b/fiasco/io/sources/non_ion_sources.py
@@ -20,7 +20,7 @@ class AbundParser(GenericParser):
     units = [None, u.dimensionless_unscaled, None]
     headings = ['Z', 'abundance', 'element']
     descriptions = ['atomic number', 'abundance relative to H', 'element']
-    fformat = fortranformat.FortranRecordReader('(I3,F7.3,A5)')
+    fformat = fortranformat.FortranRecordReader('(I2,F9.3,A2)')
 
     def __init__(self, abundance_filename, **kwargs):
         super().__init__(abundance_filename, **kwargs)


### PR DESCRIPTION
In v11, there are some abundance files with extra information after the element designation. In the current fixed width parsing code, this results in extra characters being appended to the element names which results in some elements not getting the right abundance information attached to them in the HDF5 database. This PR fixes the parser such that only two characters are always parsed from both the first and last columns. This also adds a few more tests to make sure the abundance files are parsed correctly.