### PR TITLE
Set minimum allowed versions of dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,10 @@ keywords = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-  "astropy",
-  "fortranformat",
-  "h5py",
-  "numpy<2.3.0",
+  "astropy>=5.2",
+  "fortranformat>=2",
+  "h5py>=3.9",
+  "numpy>=1.25,<2.3.0",
   "plasmapy>=2024.10.0",
 ]
 
@@ -56,30 +56,30 @@ Issues = "https://github.com/wtbarnes/fiasco/issues/"
 all = ["fiasco"]
 test = [
   "fiasco[all]",
-  "asdf-astropy",
+  "asdf-astropy>=0.5",
   "asdf>=3.1",
-  "matplotlib",
-  "pytest-astropy",
-  "pytest-cov",
-  "pytest",
+  "matplotlib>=3.8",
+  "pytest-astropy>=0.11",
+  "pytest-cov>=5",
+  "pytest>=8",
 ]
 test_idl = [
   "fiasco[test]",
-  "hissw",
-  "GitPython",
+  "hissw>=2.3",
+  "GitPython>=3.1.34",
 ]
 docs =[
   "fiasco[all]",
   "aiapy>=0.10",
-  "asdf-astropy",
+  "asdf-astropy>=0.5",
   "asdf>=3.1",
-  "hissw",
-  "pydata-sphinx-theme",
-  "sphinx-automodapi",
-  "sphinx-design",
-  "sphinx-gallery",
-  "sphinx",
-  "sphinxcontrib-bibtex",
+  "hissw>=2.3",
+  "pydata-sphinx-theme>=0.16",
+  "sphinx-automodapi>=0.16",
+  "sphinx-design>=0.5",
+  "sphinx-gallery>0.14",
+  "sphinx>=8",
+  "sphinxcontrib-bibtex>=2.6",
 ]
 dev = ["fiasco[test,docs]"]
 


### PR DESCRIPTION
This PR updates `pyproject.toml` to specify explicit minimum allowed versions of required and optional dependencies. 🥦 

I generally followed the [SPEC 0](https://scientific-python.org/specs/spec-0000/) recommendation to support versions of dependencies with minor releases in the last 24 months. Please feel free to adjust. (My personal preference is to require much more recent versions of packages in `docs` & `tests` dependency sets since they're not user facing and we don't gain much by supporting doc builds with older versions of Sphinx.)

My secondary motivation for this PR is that `uv` now has `lowest` and `lowest-direct` resolution strategies which solve for an environment with the lowest allowed versions of all dependencies and direct dependencies, respectively. If minimum versions are not specified, then the environments could potentially include `v0.0.0.1` of some packages. 😅  Specifying the lowest versions of dependencies also means that we can run tests to make sure the minimal dependencies are accurate.

My primary motivation for this PR is that I wanted to say hi and celebrate the new release of fiasco! 🙃 