### PR TITLE
Update versions of pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.4.4"
+    rev: "v0.12.7"
     hooks:
       - id: ruff
         args: ["--fix"]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 6.0.1
     hooks:
     - id: isort
       name: isort
@@ -17,7 +17,7 @@ repos:
       - python
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-ast
       - id: check-case-conflict
@@ -32,7 +32,7 @@ repos:
         exclude: ".*(.fits|.fts|.fit|.txt|.bib|.pro|.asdf|.json|tca.*)$"
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.4.1
     hooks:
       - id: codespell
         additional_dependencies:


### PR DESCRIPTION
The purpose of this PR is to run `pre-commit autoupdate` and update the code accordingly.  There are a few syntax errors found by ruff.