### PR TITLE
Make pytest report the slowest running tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,8 @@ commands =
     --cov-report=xml \
     --cov=fiasco \
     {toxinidir}/docs \
+    --durations=10 \
+    --durations-min=0.5 \
     {posargs}
 
 [testenv:build_docs{,-gallery}]


### PR DESCRIPTION
This PR adds the `--durations` flag to pytest to print out the tests with the slowest durations, and the `--durations-min` flag to set the minimum duration to that would be reported.

> [!CAUTION]
> The `--durations-min` is actually in seconds, despite the ambiguous name.