### PR TITLE
Pin `aiapy` to fix docs build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ test_idl = [
 ]
 docs =[
   "fiasco[all]",
-  "aiapy<0.11,!=0.10.2",
+  "aiapy==0.10.0",
   "asdf-astropy>=0.5",
   "asdf>=3.1",
   "hissw>=2.3",


### PR DESCRIPTION
Pin aiapy to v0.10.0 to fix docs build. This is a follow up to #422 and a stop gap until #423 is actually fixed.