### PR TITLE
Remove upper limit on NumPy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "astropy>=5.2",
   "fortranformat>=2",
   "h5py>=3.9",
-  "numpy>=1.25,<2.3.0",
+  "numpy>=1.25",
   "plasmapy>=2024.10.0",
 ]
 


### PR DESCRIPTION
For some reason, I added an upper limit to NumPy in #403. This PR removes that upper limit. My goal here is to either remove an unnecessary upper limit, or rediscover the reason why I had added it in the first place. 😅
