### PR TITLE
Fix level_populations matrix solve shapes for numpy<2 compatibility

### DIFF
--- a/changelog/450.bugfix.rst
+++ b/changelog/450.bugfix.rst
@@ -1,1 +1,0 @@
-Fix a ``ValueError`` in `fiasco.Ion.level_populations` (and therefore `fiasco.Ion.contribution_function`) when running with ``numpy < 2``, caused by the shape of the right-hand side passed to `numpy.linalg.solve`.

--- a/changelog/450.bugfix.rst
+++ b/changelog/450.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a ``ValueError`` in `fiasco.Ion.level_populations` (and therefore `fiasco.Ion.contribution_function`) when running with ``numpy < 2``, caused by the shape of the right-hand side passed to `numpy.linalg.solve`.

--- a/fiasco/ions.py
+++ b/fiasco/ions.py
@@ -634,9 +634,15 @@ Using Datasets:
                 c_matrix = self._build_coefficient_matrix(d, include_protons=include_protons)
             # Invert matrix
             c_matrix[:, -1, :] = 1.*c_matrix.unit
-            b = np.zeros(c_matrix.shape[2:])
-            b[-1] = 1.0
-            pop = np.linalg.solve(c_matrix.value, b)
+            # NOTE: c_matrix is a stack of matrices, one per temperature, with shape
+            # (n_temperature, n_levels, n_levels). Give the right-hand side an explicit
+            # trailing axis, shape (n_temperature, n_levels, 1), so that np.linalg.solve
+            # dispatches on the same (m,m),(m,n)->(m,n) signature under both numpy<2 and
+            # numpy>=2. A 1D right-hand side is only broadcast over the stack by numpy>=2,
+            # and raises on numpy<2 (see gh#447).
+            b = np.zeros(c_matrix.shape[:-1] + (1,))
+            b[..., -1, 0] = 1.0
+            pop = np.linalg.solve(c_matrix.value, b)[..., 0]
             pop[pop<0] = 0.0
             np.divide(pop, pop.sum(axis=1)[:, np.newaxis], out=pop)
             # Apply ionization/recombination correction


### PR DESCRIPTION
Fixes #447.

**Symptom.** `Ion.contribution_function()` → `Ion.level_populations()` raises `ValueError: solve: Input operand 1 does not have enough dimensions (has 1, gufunc core with signature (m,m),(m,n)->(m,n) requires 2)` under `numpy < 2` (e.g. 1.26.4), while succeeding under `numpy >= 2`. This matches @jwreep's finding in the thread: identical fiasco and CHIANTI versions, differing only in numpy.

**Root cause.** `level_populations` builds a stack of coefficient matrices `c_matrix.value` of shape `(n_temperature, n_levels, n_levels)` and solves it against a right-hand side that pins the normalization row. That right-hand side was `b = np.zeros(c_matrix.shape[2:])` — a 1D array of shape `(n_levels,)`. `numpy.linalg.solve`'s gufunc dispatch treats a 1D `b` as a broadcastable stack-of-vectors only when `b.ndim == a.ndim - 1`; here `1 != 2`, so it falls to the `(m,m),(m,n)->(m,n)` matrix signature. numpy>=2.0 added a special case that broadcasts a genuinely-1D `b` across the batch (so it works there), but numpy<2 has no such case and raises. Since `pyproject.toml` declares `numpy>=1.25`, this crashes for any supported user on numpy 1.25/1.26.

**Fix.** Give `b` an explicit trailing singleton axis, shape `(n_temperature, n_levels, 1)`, so `solve` dispatches on the same signature under both numpy majors, then squeeze the trailing axis off the result. This is numerically identical to the previous behaviour on numpy>=2 and removes all version-dependent dispatch.

Note: the naive alternative of broadcasting `b` to `(n_temperature, n_levels)` is *not* correct — under numpy>=2 that shape is reinterpreted as the `(m,n)` core block and either errors (when `n_temperature != n_levels`) or returns a wrong-shaped result (when they coincide). And pinning a `numpy>=2` floor alone would not fix the bug for the currently-declared `numpy>=1.25` support range — it would be a breaking dependency bump rather than a fix. The shape correction is the necessary change; a floor bump would only be optional belt-and-suspenders.

**Verification** (macOS arm64, two virtualenvs):

- `fiasco/tests/test_ion.py::test_level_populations` and `::test_contribution_function` already exercise the vulnerable shape (100-point temperature grid vs real `n_levels`) and assert hardcoded numeric populations, so they are genuine numerical-equivalence checks. On `numpy==1.26.4` they fail before this change with the reported `ValueError` and pass after; on `numpy==2.5.1` they pass before and after. (`pytest --pyargs fiasco --ascii-dbase-root ~/.chianti -k "level_populations or contribution_function"`)
- A standalone, CHIANTI-independent check confirms the fixed `(n_temperature, n_levels, 1)` right-hand side matches an independent per-temperature `np.linalg.solve` loop exactly, under both numpy 1.26.4 and 2.5.1.
- `ruff check fiasco/ions.py` is clean.

Optional follow-up (out of scope here): fiasco's declared `numpy>=1.25` floor is never exercised in CI (no `oldestdeps` tox env), which is why this shipped silently; an oldest-deps job would guard against this class of regression.
