### PR TITLE
Backport PR #459 on branch 0.8 (Use elvlc data to compute energy spacing in upsilon calculation rather than scups data)

### DIFF
--- a/examples/idl_comparisons/goft_comparison.py
+++ b/examples/idl_comparisons/goft_comparison.py
@@ -47,7 +47,7 @@ def plot_idl_comparison(x, y_idl, y_python, fig, n_rows, i_row, quantity_name, t
     ax2.axhline(y=1, color='k', ls=':')
     if i_row == 0:
         ax2.set_title('fiasco / IDL')
-    diff_limit = .05
+    diff_limit = 0.02
     ax2.set_ylim(1-diff_limit, 1+diff_limit)
     # Normalized difference
     ax3 = fig.add_subplot(n_rows, 3, i_row+3, sharex=ax1)

--- a/fiasco/ions.py
+++ b/fiasco/ions.py
@@ -418,10 +418,9 @@ Using Datasets:
         --------
         fiasco.util.burgess_tully_descale : Descale and interpolate :math:`\Upsilon`.
         """
-        kBTE = np.outer(self.thermal_energy, 1.0 / self._scups['delta_energy'])
         upsilon = burgess_tully_descale(self._scups['bt_t'],
                                         self._scups['bt_upsilon'],
-                                        kBTE.T,
+                                        np.outer(self.thermal_energy, 1/self._scups['delta_energy']).T,
                                         self._scups['bt_c'],
                                         self._scups['bt_type'])
         upsilon = u.Quantity(np.where(upsilon > 0., upsilon, 0.))
@@ -484,9 +483,12 @@ Using Datasets:
         electron_collision_deexcitation_rate : De-excitation rate due to collisions
         """
         J = self.levels.total_angular_momentum
-        omega_upper = 2. * J[vectorize_where(self.levels.level, self._scups['upper_level'])] + 1.
-        omega_lower = 2. * J[vectorize_where(self.levels.level, self._scups['lower_level'])] + 1.
-        kBTE = np.outer(1./self.thermal_energy, self._scups['delta_energy'])
+        level_upper = vectorize_where(self.levels.level, self._scups['upper_level'])
+        level_lower = vectorize_where(self.levels.level, self._scups['lower_level'])
+        omega_upper = 2. * J[level_upper] + 1.
+        omega_lower = 2. * J[level_lower] + 1.
+        delta_energy = self.levels.energy[level_upper] - self.levels.energy[level_lower]
+        kBTE = np.outer(1./self.thermal_energy, delta_energy)
         return omega_upper / omega_lower * self.electron_collision_deexcitation_rate * np.exp(-kBTE)
 
     @cached_property

--- a/fiasco/tests/idl/test_idl_goft.py
+++ b/fiasco/tests/idl/test_idl_goft.py
@@ -97,4 +97,4 @@ def test_idl_compare_goft(idl_env, hdf5_dbase_root, dbase_version, chianti_idl_v
     goft_idl = idl_result['contribution_function']
     i_compare = np.where(goft_idl>=goft_idl.max()*1e-3)
     # Compare results
-    assert u.allclose(goft_idl[i_compare], goft_python[i_compare], atol=None, rtol=0.05)
+    assert u.allclose(goft_idl[i_compare], goft_python[i_compare], atol=None, rtol=0.01)

--- a/fiasco/tests/test_collections.py
+++ b/fiasco/tests/test_collections.py
@@ -117,7 +117,7 @@ def test_two_photon(collection, wavelength, index_w, hdf5_dbase_root):
     wavelength = np.atleast_1d(wavelength)
     assert tp.shape == temperature.shape + (1, ) + wavelength.shape
     # This value has not been checked for correctness
-    assert u.allclose(tp[30, 0, index_w], 3.48586904e-27 * u.Unit('erg cm3 s-1 Angstrom-1'))
+    assert u.allclose(tp[30, 0, index_w], 3.4862925e-27 * u.Unit('erg cm3 s-1 Angstrom-1'))
 
 
 @pytest.mark.requires_dbase_version('>= 8')

--- a/fiasco/tests/test_ion.py
+++ b/fiasco/tests/test_ion.py
@@ -253,9 +253,9 @@ def test_level_populations(ion):
     pop = ion.level_populations(1e8 * u.cm**-3)
     assert pop.shape == ion.temperature.shape + (1,) + ion._elvlc['level'].shape
     # This value has not been checked for correctness
-    assert u.allclose(pop[0, 0, 0], 0.011643747849652244)
+    assert u.allclose(pop[0, 0, 0], 0.0111401417)
     # Check that the total populations are normalized to 1 for all temperatures
-    assert u.allclose(pop.squeeze().sum(axis=1), 1, atol=None, rtol=1e-15)
+    assert u.allclose(pop.squeeze().sum(axis=1), 1, atol=None, rtol=1e-10)
 
 
 @pytest.mark.requires_dbase_version('>= 8')
@@ -272,7 +272,7 @@ def test_contribution_function(ion):
     wvl_bb = ion.transitions.wavelength[ion.transitions.is_bound_bound]
     assert cont_func.shape == ion.temperature.shape + (1, ) + wvl_bb.shape
     # This value has not been tested for correctness
-    assert u.allclose(cont_func[0, 0, 0], 2.51408088e-30 * u.cm**3 * u.erg / u.s)
+    assert u.allclose(cont_func[0, 0, 0], 2.44349045e-30 * u.cm**3 * u.erg / u.s)
 
 
 @pytest.mark.requires_dbase_version('>= 8')
@@ -358,7 +358,7 @@ def test_emissivity(ion):
     wvl_bb = ion.transitions.wavelength[ion.transitions.is_bound_bound]
     assert emm.shape == ion.temperature.shape + (1, ) + wvl_bb.shape
     # This value has not been tested for correctness
-    assert u.allclose(emm[0, 0, 0], 2.18000422e-16 * u.erg / u.cm**3 / u.s)
+    assert u.allclose(emm[0, 0, 0], 2.11879311e-16 * u.erg / u.cm**3 / u.s)
 
 
 @pytest.mark.requires_dbase_version('>= 8')


### PR DESCRIPTION
Backport PR #459: Use elvlc data to compute energy spacing in upsilon calculation rather than scups data