### PR TITLE
Fast X: level populations edition

### DIFF
--- a/fiasco/base.py
+++ b/fiasco/base.py
@@ -16,6 +16,7 @@ from fiasco.io.factory import all_subclasses
 from fiasco.io.generic import GenericIonParser
 from fiasco.util import check_database, parse_ion_name, periodic_table_period
 from fiasco.util.exceptions import MissingIonError
+from fiasco.util.util import _atomic_number, _atomic_symbol, _element_name
 
 __all__ = ['IonBase']
 
@@ -70,17 +71,17 @@ class IonBase:
     @property
     def atomic_number(self):
         """The atomic number of the element, :math:`Z`."""
-        return plasmapy.particles.atomic_number(self._base_rep[0])
+        return _atomic_number(self._base_rep[0])
 
     @property
     def element_name(self):
         """The full name of the element, e.g. "hydrogen"."""
-        return plasmapy.particles.element_name(self.atomic_number)
+        return _element_name(self.atomic_number)
 
     @property
     def atomic_symbol(self):
         """The standard atomic symbol for the element, e.g. "H" for hydrogen."""
-        return plasmapy.particles.atomic_symbol(self.atomic_number)
+        return _atomic_symbol(self.atomic_number)
 
     @property
     def ion_name(self):
@@ -101,7 +102,7 @@ class IonBase:
     def isoelectronic_sequence(self):
         "Atomic symbol denoting to which isoelectronic sequence this ion belongs."
         if (Z_iso := self.atomic_number - self.charge_state) > 0:
-            return plasmapy.particles.atomic_symbol(Z_iso)
+            return _atomic_symbol(Z_iso)
 
     @property
     @u.quantity_input

--- a/fiasco/base.py
+++ b/fiasco/base.py
@@ -4,8 +4,10 @@ Base classes for access to CHIANTI ion data.
 These classes are not meant to be instantiated directly by the user.
 """
 import astropy.units as u
+import pathlib
 import plasmapy.particles
 
+from functools import lru_cache
 from packaging.version import Version
 from plasmapy.utils import roman
 
@@ -19,6 +21,21 @@ from fiasco.util.exceptions import MissingIonError
 from fiasco.util.util import _atomic_number, _atomic_symbol, _element_name
 
 __all__ = ['IonBase']
+
+
+@lru_cache(maxsize=None)
+def _ion_names_in_dbase(hdf5_dbase_root, mtime_ns, size):
+    # Memoized set of available ion names per database file. The modification
+    # time and size of the file are part of the key such that the cache is
+    # invalidated if the database is rebuilt.
+    return frozenset(fiasco.list_ions(hdf5_dbase_root, sort=False))
+
+
+@lru_cache(maxsize=None)
+def _dbase_fiasco_version(hdf5_dbase_root, mtime_ns, size):
+    # Memoized fiasco version of the database file (see _ion_names_in_dbase)
+    # to avoid opening the database on every ion instantiation.
+    return DataIndexer(hdf5_dbase_root, '/').fiasco_version
 
 
 class IonBase:
@@ -47,7 +64,8 @@ class IonBase:
         else:
             self.hdf5_dbase_root = hdf5_dbase_root
         check_database(self.hdf5_dbase_root, **kwargs)
-        if self.ion_name not in fiasco.list_ions(self.hdf5_dbase_root, sort=False):
+        stat = pathlib.Path(self.hdf5_dbase_root).stat()
+        if self.ion_name not in _ion_names_in_dbase(str(self.hdf5_dbase_root), stat.st_mtime_ns, stat.st_size):
             raise MissingIonError(f'{self.ion_name} not found in {self.hdf5_dbase_root}')
         # Put import here to avoid circular imports
         from fiasco import log
@@ -57,7 +75,8 @@ class IonBase:
 
     def _check_dbase_fiasco_version(self):
         "Warn if database was generated with an earlier version of fiasco."
-        dbase_version = DataIndexer(self.hdf5_dbase_root, '/').fiasco_version
+        stat = pathlib.Path(self.hdf5_dbase_root).stat()
+        dbase_version = _dbase_fiasco_version(str(self.hdf5_dbase_root), stat.st_mtime_ns, stat.st_size)
         if dbase_version is not None:
             current_version = Version(fiasco.__version__)
             if dbase_version < current_version and not current_version.is_devrelease:

--- a/fiasco/elements.py
+++ b/fiasco/elements.py
@@ -10,6 +10,7 @@ from functools import cached_property
 import fiasco
 
 from fiasco.util import parse_ion_name
+from fiasco.util.util import _atomic_number
 
 __all__ = ['Element']
 
@@ -37,7 +38,7 @@ class Element(fiasco.IonCollection):
     def __init__(self, element_name, temperature: u.K, **kwargs):
         if isinstance(element_name, str):
             element_name = element_name.capitalize()
-        Z = plasmapy.particles.atomic_number(element_name)
+        Z = _atomic_number(element_name)
         ion_list = []
         for i in range(Z + 1):
             ion = fiasco.Ion((Z, i+1), temperature, **kwargs)

--- a/fiasco/fiasco.py
+++ b/fiasco/fiasco.py
@@ -3,7 +3,6 @@ Package-level functions.
 """
 import astropy.units as u
 import numpy as np
-import plasmapy.particles
 
 from plasmapy.particles.exceptions import InvalidParticleError
 from scipy.interpolate import interp1d
@@ -12,6 +11,7 @@ import fiasco
 
 from fiasco.io import DataIndexer
 from fiasco.util import parse_ion_name
+from fiasco.util.util import _atomic_number, _atomic_symbol
 
 __all__ = [
     'list_elements',
@@ -40,11 +40,11 @@ def list_elements(hdf5_dbase_root=None, sort=True):
     root = DataIndexer.create_indexer(hdf5_dbase_root, '/')
     for f in root.fields:
         try:
-            elements.append(plasmapy.particles.atomic_symbol(f.capitalize()))
+            elements.append(_atomic_symbol(f.capitalize()))
         except InvalidParticleError:
             continue
     if sort:
-        elements = sorted(elements, key=lambda x: plasmapy.particles.atomic_number(x))
+        elements = sorted(elements, key=lambda x: _atomic_number(x))
     return elements
 
 
@@ -69,7 +69,7 @@ def list_ions(hdf5_dbase_root=None, sort=True):
         ions = []
         for f in root.fields:
             try:
-                el = plasmapy.particles.atomic_symbol(f.capitalize())
+                el = _atomic_symbol(f.capitalize())
                 for i in root[f].fields:
                     if f == i.split('_')[0]:
                         ions.append(f"{el} {i.split('_')[1]}")
@@ -77,7 +77,7 @@ def list_ions(hdf5_dbase_root=None, sort=True):
                 continue
     # Optional because adds significant overhead
     if sort:
-        ions = sorted(ions, key=lambda x: (plasmapy.particles.atomic_number(x.split()[0]),
+        ions = sorted(ions, key=lambda x: (_atomic_number(x.split()[0]),
                                            int(x.split()[1])))
     # NOTE: when grabbing straight from the index and not sorting, the result will be
     # a numpy array. Cast to a list to make sure the return type is consistent for
@@ -130,7 +130,7 @@ def get_isoelectronic_sequence(element, hdf5_dbase_root=None):
     hdf5_dbase_root: path-like, optional
         If not specified, will default to that specified in ``fiasco.defaults``.
     """
-    Z_iso = plasmapy.particles.atomic_number(element)
+    Z_iso = _atomic_number(element)
     all_ions = list_ions(hdf5_dbase_root=hdf5_dbase_root)
 
     def _is_in_sequence(ion):
@@ -159,29 +159,37 @@ def proton_electron_ratio(temperature: u.K, **kwargs):
     h_2 = fiasco.Ion('H +1', temperature, **kwargs)
     numerator = h_2.abundance * h_2._ion_fraction[h_2._instance_kwargs['ionization_fraction']]['ionization_fraction']
     denominator = u.Quantity(np.zeros(numerator.shape))
+    instance_kwargs = h_2._instance_kwargs
+    ionization_file = instance_kwargs['ionization_fraction']
     for el_name in list_elements(h_2.hdf5_dbase_root):
-        el = fiasco.Element(el_name, temperature, **h_2._instance_kwargs)
+        # NOTE: Only the first ion of each element is instantiated because instantiating
+        # an Ion for every ionization stage of every element carries significant overhead.
+        # The ionization fraction data of each ion is instead read directly from the
+        # database and is identical to that attached to the corresponding Ion instance.
+        ion_1 = fiasco.Ion((el_name, 1), temperature, **instance_kwargs)
         try:
-            abundance = el.abundance
+            abundance = ion_1.abundance
         except KeyError:
-            abund_file = el[0]._instance_kwargs['abundance']
+            abund_file = ion_1._instance_kwargs['abundance']
             log.warning(
-                f'Not including {el.atomic_symbol}. Abundance not available from {abund_file}.')
+                f'Not including {ion_1.atomic_symbol}. Abundance not available from {abund_file}.')
             continue
-        for ion in el:
-            ionization_file = ion._instance_kwargs['ionization_fraction']
-            # NOTE: We use ._ion_fraction here rather than .ionization_fraction to avoid
-            # doing an interpolation to the temperature array every single time and instead only
+        el_lower = ion_1.atomic_symbol.lower()
+        for stage in range(1, ion_1.atomic_number + 2):
+            # NOTE: We use the ioneq data directly rather than the ionization_fraction property
+            # to avoid doing an interpolation to the temperature array every single time and instead only
             # interpolate once at the end.
             # It is assumed that the ionization_fraction temperature array for each ion is the same.
             try:
-                ionization_fraction = ion._ion_fraction[ionization_file]['ionization_fraction']
-                t_ionization_fraction = ion._ion_fraction[ionization_file]['temperature']
+                ioneq_data = DataIndexer(h_2.hdf5_dbase_root,
+                                         f'{el_lower}/{el_lower}_{stage}/ioneq')[ionization_file]
+                ionization_fraction = ioneq_data['ionization_fraction']
+                t_ionization_fraction = ioneq_data['temperature']
             except KeyError:
                 log.warning(
-                    f'Not including {ion.ion_name}. Ionization fraction not available from {ionization_file}.')
+                    f'Not including {ion_1.atomic_symbol} {stage}. Ionization fraction not available from {ionization_file}.')
                 continue
-            denominator += ionization_fraction * abundance * ion.charge_state
+            denominator += ionization_fraction * abundance * (stage - 1)
 
     ratio = numerator / denominator
     f_interp = interp1d(t_ionization_fraction.to(temperature.unit).value,

--- a/fiasco/io/datalayer.py
+++ b/fiasco/io/datalayer.py
@@ -114,12 +114,16 @@ class DataIndexerHDF5:
     def __getitem__(self, key):
         if isinstance(key, int):
             raise NotImplementedError('Iteration not supported.')
-        if key not in self:
-            raise KeyError(f'{key} not found in {self.top_level_path}')
+        # NOTE: The membership check, indexer creation, and read are all done with
+        # a single open of the HDF5 file as opening and closing the file on every
+        # access carries a non-negligible overhead.
         with h5py.File(self.hdf5_dbase_root, 'r') as hf:
-            ds = hf[self.top_level_path][key]
+            grp = hf[self.top_level_path]
+            if key not in grp:
+                raise KeyError(f'{key} not found in {self.top_level_path}')
+            ds = grp[key]
             if isinstance(ds, h5py.Group):
-                data = DataIndexer.create_indexer(
+                data = DataIndexerHDF5(
                     self.hdf5_dbase_root, '/'.join([self.top_level_path, key]))
             else:
                 if ds.attrs['unit'] == 'SKIP' or ds.dtype == 'object':

--- a/fiasco/ions.py
+++ b/fiasco/ions.py
@@ -230,6 +230,18 @@ Using Datasets:
                            self.temperature,
                            **self._instance_kwargs)
 
+    @cached_property
+    def _next_ion(self):
+        # Cached instance of the next ion for internal use such that expensive
+        # quantities computed on the next ion (e.g. rate matrices) are only
+        # computed once rather than on every call to next_ion().
+        return self.next_ion()
+
+    @cached_property
+    def _previous_ion(self):
+        # Cached instance of the previous ion for internal use (see _next_ion).
+        return self.previous_ion()
+
     @property
     @needs_dataset('elvlc', 'wgfa')
     def transitions(self):
@@ -682,13 +694,21 @@ Using Datasets:
     def _build_two_ion_coefficient_matrix(self, electron_density, include_protons=False):
         # Get coefficient matrix of recombined ion
         c_matrix_recombined = self._build_coefficient_matrix(electron_density, include_protons=include_protons)
+        # NOTE: The proton-electron ratio depends only on the temperature and the abundance and
+        # ionization fraction datasets, all of which are shared between the two ions. Seeding the
+        # cache of the next ion avoids recomputing an identical quantity.
+        if include_protons and 'proton_electron_ratio' not in self._next_ion.__dict__:
+            try:
+                self._next_ion.__dict__['proton_electron_ratio'] = self.proton_electron_ratio
+            except MissingDatasetException:
+                pass
         # Get coefficient matrix of recombining ion
         try:
-            c_matrix_recombining = self.next_ion()._build_coefficient_matrix(electron_density,
-                                                                             include_protons=include_protons)
+            c_matrix_recombining = self._next_ion._build_coefficient_matrix(electron_density,
+                                                                            include_protons=include_protons)
         except MissingDatasetException:
             self.log.warning(
-                f'No rate data available for recombining ion {self.next_ion().ion_name}. '
+                f'No rate data available for recombining ion {self._next_ion.ion_name}. '
                 f'Using single-ion model for {self.ion_name}.'
             )
             return c_matrix_recombined
@@ -696,10 +716,7 @@ Using Datasets:
         # Add terms that include both ions
         d_e = electron_density[:, np.newaxis, np.newaxis]
         rate_matrix_total += self._rate_matrix_autoionization
-        rate_matrix_total += d_e * (self._rate_matrix_ionization
-                                    + self._rate_matrix_radiative_recombination
-                                    + self._rate_matrix_dielectronic_capture
-                                    + self._rate_matrix_dielectronic_recombination)
+        rate_matrix_total += d_e * self._rate_matrix_two_ion_density_dependent
         # Add depopulating terms
         # NOTE: By summing over the rows, we are computing the processes that depopulate
         # that level by summing up all of the processes that populate *from* that level.
@@ -755,11 +772,22 @@ Using Datasets:
         return rate_matrix
 
     def _empty_rate_matrix(self, temperature_dependent=True, unit='cm3 s-1'):
-        n_levels = self.n_levels + self.next_ion().n_levels
+        n_levels = self.n_levels + self._next_ion.n_levels
         shape = (n_levels, n_levels)
         if temperature_dependent:
             shape = self.temperature.shape + shape
         return u.Quantity(np.zeros(shape), unit)
+
+    @cached_property
+    @u.quantity_input
+    def _rate_matrix_two_ion_density_dependent(self) -> u.Unit('cm3 s-1'):
+        # Sum of the density-dependent two-ion rate matrices. This sum is
+        # independent of density so it is cached to avoid recomputing it for
+        # every density value in the level populations calculation.
+        return (self._rate_matrix_ionization
+                + self._rate_matrix_radiative_recombination
+                + self._rate_matrix_dielectronic_capture
+                + self._rate_matrix_dielectronic_recombination)
 
     @cached_property
     @u.quantity_input
@@ -775,7 +803,7 @@ Using Datasets:
         rate_matrix = self._empty_rate_matrix()
         try:
             # NOTE: Using copy to avoid in-place modification of cached property
-            rr_rate_ground = self.next_ion().radiative_recombination_rate.copy()
+            rr_rate_ground = self._next_ion.radiative_recombination_rate.copy()
         except MissingDatasetException:
             rr_rate_ground = u.Quantity(np.zeros(self.temperature.shape), 'cm3 s-1')
         if self._has_dataset('rrlvl'):
@@ -822,7 +850,7 @@ Using Datasets:
 
     def _dielectronic_capture_rate(self, level_lower, level_upper, A_auto):
         # See Eq. A4 of Dere et al. (2019)
-        next_ion = self.next_ion()
+        next_ion = self._next_ion
         levels_recombined = self[vectorize_where(self.levels.level, level_upper)]
         levels_recombining = next_ion[vectorize_where(next_ion.levels.level, level_lower)]
         g_ratio = levels_recombined.weight / levels_recombining.weight
@@ -861,7 +889,7 @@ Using Datasets:
         rate_matrix = self._empty_rate_matrix()
         # Compute ground-ground dielectronic recombination rate
         try:
-            dr_rate_ground = self.next_ion().dielectronic_recombination_rate
+            dr_rate_ground = self._next_ion.dielectronic_recombination_rate
         except MissingDatasetException:
             dr_rate_ground = u.Quantity(np.zeros(self.temperature.shape), 'cm3 s-1')
         # NOTE: Explicitly not using a decorator here in order to return an empty matrix
@@ -1054,14 +1082,14 @@ Using Datasets:
         numerator = np.zeros(population.shape)
         try:
             upper_level_ionization, ionization_rate = self._level_resolved_ionization_rate
-            ionization_fraction_previous = self.previous_ion().ionization_fraction.value[:, np.newaxis]
+            ionization_fraction_previous = self._previous_ion.ionization_fraction.value[:, np.newaxis]
             upper_index_ionization = upper_level_ionization-1
             numerator[:, upper_index_ionization] += (ionization_rate * ionization_fraction_previous).to_value('cm3 s-1')
         except MissingDatasetException:
             pass
         try:
             upper_level_recombination, recombination_rate = self._level_resolved_recombination_rate
-            ionization_fraction_next = self.next_ion().ionization_fraction.value[:, np.newaxis]
+            ionization_fraction_next = self._next_ion.ionization_fraction.value[:, np.newaxis]
             upper_index_recombination = upper_level_recombination-1
             numerator[:, upper_index_recombination] += (recombination_rate * ionization_fraction_next).to_value('cm3 s-1')
         except MissingDatasetException:

--- a/fiasco/util/util.py
+++ b/fiasco/util/util.py
@@ -7,6 +7,7 @@ import pathlib
 import plasmapy.particles
 import sys
 
+from functools import lru_cache
 from packaging.version import Version
 from plasmapy.utils import roman
 
@@ -14,6 +15,25 @@ FIASCO_HOME = pathlib.Path.home() / '.fiasco'
 FIASCO_RC = FIASCO_HOME / 'fiascorc'
 
 __all__ = ['setup_paths', 'get_chianti_catalog', 'read_chianti_version', 'parse_ion_name']
+
+
+@lru_cache(maxsize=None)
+def _atomic_number(element):
+    # Memoized version of plasmapy.particles.atomic_number as constructing
+    # a plasmapy Particle on every call is comparatively expensive.
+    return plasmapy.particles.atomic_number(element)
+
+
+@lru_cache(maxsize=None)
+def _atomic_symbol(atomic_number):
+    # Memoized version of plasmapy.particles.atomic_symbol (see _atomic_number).
+    return plasmapy.particles.atomic_symbol(atomic_number)
+
+
+@lru_cache(maxsize=None)
+def _element_name(atomic_number):
+    # Memoized version of plasmapy.particles.element_name (see _atomic_number).
+    return plasmapy.particles.element_name(atomic_number)
 
 
 def parse_ion_name(ion_name):
@@ -40,7 +60,7 @@ def parse_ion_name(ion_name):
     # Parse element string
     if isinstance(element, str):
         element = element.capitalize()
-    element = plasmapy.particles.atomic_number(element)
+    element = _atomic_number(element)
     # Parse ion string
     if isinstance(ion, str):
         if '+' in ion:


### PR DESCRIPTION
Test to see if Claude MD can speed up some code in this repo.
According to Claude (unverified), these are the speeds up.

```
    ┌───────────────────────────┬────────────────┬────────┐
    │ Case                      │ Original       │ Now    │
    ├───────────────────────────┼────────────────┼────────┤
    │ Fe XXIII two-ion (21T×9n) │ 73.5 s         │ 5.2 s  │
    ├───────────────────────────┼────────────────┼────────┤
    │ Ca XVIII two-ion          │ 74.3 s         │ 6.4 s  │
    ├───────────────────────────┼────────────────┼────────┤
    │ O VI default              │ 73.3 s         │ 6.9 s  │
    ├───────────────────────────┼────────────────┼────────┤
    │ Fe XII single-ion         │ 9.9 s          │ 3.4 s  │
    ├───────────────────────────┼────────────────┼────────┤
    │ Coupled n–T               │ 14.5 s         │ 1.4 s  │
    ├───────────────────────────┼────────────────┼────────┤
    │ proton_electron_ratio     │ ~39 s* / 1.4 s │ 0.38 s │
    └───────────────────────────┴────────────────┴────────┘
```

Now whether the code is good, is another question. 