### PR TITLE
Include all packages in tool.setuptools during build from Git

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,13 @@ docs =[
 dev = ["fiasco[test,docs]"]
 
 [tool.setuptools]
-packages = ["fiasco"]
+packages = [
+  "fiasco",
+  "fiasco.data",
+  "fiasco.io",
+  "fiasco.tests",
+  "fiasco.util"
+]
 
 [tool.setuptools_scm]
 write_to = "fiasco/version.py"


### PR DESCRIPTION
With flat layout it needs to list all sub packages, otherwise "data", "io" tests" and "util" are not included during build from Git checkout.

See: https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#flat-layout